### PR TITLE
Fix/hide audio transcription

### DIFF
--- a/src/components/LukeAudioWidget.tsx
+++ b/src/components/LukeAudioWidget.tsx
@@ -17,6 +17,7 @@ interface LukeAudioWidgetProps {
   token: string;
   lukeConfig: LukeConfig;
   forceMute?: boolean;
+  showTranscription?: boolean;
   mode?: LukeUIMode;
   onTranscriptComplete?: (
     transcript: string,
@@ -31,6 +32,7 @@ interface LukeAudioWidgetProps {
 const LukeAudioInner: React.FC<{
   lukeConfig: LukeConfig;
   forceMute?: boolean;
+  showTranscription?: boolean;
   mode?: LukeUIMode;
   onTranscriptComplete?: (
     transcript: string,
@@ -38,7 +40,13 @@ const LukeAudioInner: React.FC<{
     timestamp: Date,
     sequence: number,
   ) => void;
-}> = ({ lukeConfig, forceMute = false, mode = "inline", onTranscriptComplete }) => {
+}> = ({
+  lukeConfig,
+  forceMute = false,
+  showTranscription = true,
+  mode = "inline",
+  onTranscriptComplete,
+}) => {
   const {
     isConnected,
     providers,
@@ -113,7 +121,7 @@ const LukeAudioInner: React.FC<{
   return (
     <VoiceClientUI
       mode={mode}
-      showTranscription={true}
+      showTranscription={showTranscription}
       showProviderSelector={false}
       showExpandButton={false}
       onTranscription={handleTranscription}
@@ -127,6 +135,7 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
   token,
   lukeConfig,
   forceMute,
+  showTranscription,
   mode = "inline",
   onTranscriptComplete,
 }) => {
@@ -135,6 +144,7 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
       <LukeAudioInner
         lukeConfig={lukeConfig}
         forceMute={forceMute}
+        showTranscription={showTranscription}
         mode={mode}
         onTranscriptComplete={onTranscriptComplete}
       />

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -285,16 +285,8 @@ export const Chat = () => {
             setLukeConfig(response.data.leia.lukeConfig);
           }
         }
-        if (
-          response.data.leia?.hideAudioTranscription !== undefined ||
-          response.data.leia?.hideTranscription !== undefined
-        ) {
-          setHideAudioTranscription(
-            Boolean(
-              response.data.leia.hideAudioTranscription ??
-                response.data.leia.hideTranscription
-            )
-          );
+        if (response.data.leia?.hideAudioTranscription !== undefined) {
+          setHideAudioTranscription(Boolean(response.data.leia.hideAudioTranscription));
         }
         let messages = response.data.messages;
 
@@ -675,7 +667,6 @@ export const Chat = () => {
       {audioMode === "luke" ? (
         /* Vista Luke - Componente nativo en el centro */
         <div className="flex-1 flex flex-col overflow-hidden">
-          {hideAudioTranscription && <LiveTranscriptionNotice />}
           {lukeToken.isReady && lukeConfig ? (
             <LukeAudioWidget
               wsUrl={lukeToken.wsUrl!}
@@ -769,9 +760,7 @@ export const Chat = () => {
             ref={chatMessagesRef}
             className="max-w-3xl mx-auto space-y-4 py-4"
           >
-            {audioMode === "audio" && hideAudioTranscription && (
-              <LiveTranscriptionNotice />
-            )}
+            {hideAudioTranscription && (<LiveTranscriptionNotice/>)}
             {!hideAudioTranscription && messages.map((msg, index, visibleMessages) => (
               <div
                 key={msg.id || index}

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -675,6 +675,7 @@ export const Chat = () => {
       {audioMode === "luke" ? (
         /* Vista Luke - Componente nativo en el centro */
         <div className="flex-1 flex flex-col overflow-hidden">
+          {hideAudioTranscription && <LiveTranscriptionNotice />}
           {lukeToken.isReady && lukeConfig ? (
             <LukeAudioWidget
               wsUrl={lukeToken.wsUrl!}

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -681,6 +681,7 @@ export const Chat = () => {
               token={lukeToken.token!}
               lukeConfig={lukeConfig}
               forceMute={showInstructions}
+              showTranscription={!hideAudioTranscription}
               mode="inline"
               onTranscriptComplete={handleTranscriptComplete}
             />

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -92,7 +92,7 @@ export const Chat = () => {
   const [retryingMessage, setRetryingMessage] = useState(false);
   const [audioMode, setAudioMode] = useState<"text" | "audio" | "luke">("text");
   const [lukeConfig, setLukeConfig] = useState<{ provider: string; voice: string } | null>(null);
-  const [hideTranscription, setHideTranscription] = useState(false);
+  const [hideAudioTranscription, setHideAudioTranscription] = useState(false);
   const chatMessagesRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const lastLeiaMessageRef = useRef<HTMLDivElement>(null);
@@ -285,8 +285,16 @@ export const Chat = () => {
             setLukeConfig(response.data.leia.lukeConfig);
           }
         }
-        if (response.data.leia?.hideTranscription !== undefined) {
-          setHideTranscription(Boolean(response.data.leia.hideTranscription));
+        if (
+          response.data.leia?.hideAudioTranscription !== undefined ||
+          response.data.leia?.hideTranscription !== undefined
+        ) {
+          setHideAudioTranscription(
+            Boolean(
+              response.data.leia.hideAudioTranscription ??
+                response.data.leia.hideTranscription
+            )
+          );
         }
         let messages = response.data.messages;
 
@@ -759,10 +767,10 @@ export const Chat = () => {
             ref={chatMessagesRef}
             className="max-w-3xl mx-auto space-y-4 py-4"
           >
-            {audioMode === "audio" && hideTranscription && (
+            {audioMode === "audio" && hideAudioTranscription && (
               <LiveTranscriptionNotice />
             )}
-            {!hideTranscription && messages.map((msg, index, visibleMessages) => (
+            {!hideAudioTranscription && messages.map((msg, index, visibleMessages) => (
               <div
                 key={msg.id || index}
                 id={`message-${msg.id || index}`}

--- a/src/views/Replication.tsx
+++ b/src/views/Replication.tsx
@@ -56,11 +56,11 @@ interface Replication {
       runnerConfiguration: {
         provider: string;
         audioMode?: "realtime" | "luke" | null;
+        hideAudioTranscription?: boolean | null;
         realtimeConfig?: {
           model?: string;
           voice?: string;
           instructions?: string;
-          hideTranscription?: boolean;
           turnDetection?: {
             type?: "server_vad" | "none";
             threshold?: number;
@@ -1086,12 +1086,29 @@ export const Replication: React.FC = () => {
                               "runnerConfiguration.audioMode",
                               null
                             );
+                            handleLocalLeiaChange(
+                              idx,
+                              "runnerConfiguration.hideAudioTranscription",
+                              null
+                            );
                           } else if (value === "realtime") {
                             handleLocalLeiaChange(
                               idx,
                               "runnerConfiguration.audioMode",
                               "realtime"
                             );
+                            if (
+                              item.runnerConfiguration.hideAudioTranscription ===
+                                null ||
+                              item.runnerConfiguration.hideAudioTranscription ===
+                                undefined
+                            ) {
+                              handleLocalLeiaChange(
+                                idx,
+                                "runnerConfiguration.hideAudioTranscription",
+                                false
+                              );
+                            }
                             if (!item.runnerConfiguration.realtimeConfig) {
                               handleLocalLeiaChange(
                                 idx,
@@ -1100,7 +1117,6 @@ export const Replication: React.FC = () => {
                                   model: "gpt-4o-realtime-preview",
                                   voice: "marin",
                                   instructions: "",
-                                  hideTranscription: false,
                                   turnDetection: {
                                     type: "server_vad",
                                     threshold: 0.5,
@@ -1116,6 +1132,18 @@ export const Replication: React.FC = () => {
                               "runnerConfiguration.audioMode",
                               "luke"
                             );
+                            if (
+                              item.runnerConfiguration.hideAudioTranscription ===
+                                null ||
+                              item.runnerConfiguration.hideAudioTranscription ===
+                                undefined
+                            ) {
+                              handleLocalLeiaChange(
+                                idx,
+                                "runnerConfiguration.hideAudioTranscription",
+                                false
+                              );
+                            }
                             if (!item.runnerConfiguration.lukeConfig) {
                               handleLocalLeiaChange(
                                 idx,
@@ -1135,6 +1163,30 @@ export const Replication: React.FC = () => {
                         <option value="luke">Luke</option>
                       </select>
                     </div>
+
+                    {item.runnerConfiguration.audioMode && (
+                      <div className="ml-4">
+                        <div className="flex items-center space-x-2 mt-2">
+                          <ChatBubbleBottomCenterIcon className="h-4 w-4 text-gray-600" />
+                          <label className="text-sm text-gray-700 font-medium">
+                            Hide audio transcription:
+                          </label>
+                          <Switch
+                            checked={
+                              item.runnerConfiguration
+                                .hideAudioTranscription || false
+                            }
+                            onChange={(checked) =>
+                              handleLocalLeiaChange(
+                                idx,
+                                "runnerConfiguration.hideAudioTranscription",
+                                checked
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+                    )}
 
                     {item.runnerConfiguration.audioMode === "realtime" && (
                       <div className="ml-4 space-y-2 text-sm">
@@ -1175,25 +1227,6 @@ export const Replication: React.FC = () => {
                               onChange={() => setShowAllVoices(!showAllVoices)}
                             ></Switch>
                           </label>
-                        </div>
-                        <div className="flex items-center space-x-2 mt-2">
-                          <ChatBubbleBottomCenterIcon className="h-4 w-4 text-gray-600" />
-                          <label className="text-sm text-gray-700 font-medium">
-                            Hide live transcription:
-                          </label>
-                          <Switch
-                            checked={
-                              item.runnerConfiguration.realtimeConfig
-                                ?.hideTranscription || false
-                            }
-                            onChange={(checked) =>
-                              handleLocalLeiaChange(
-                                idx,
-                                "runnerConfiguration.realtimeConfig.hideTranscription",
-                                checked
-                              )
-                            }
-                          />
                         </div>
                         <div className="text-xs text-purple-600 flex items-center gap-1">
                           <svg


### PR DESCRIPTION
Note:

To hide the transcription when Luke is selected, I decided to use Luke’s showTranscription prop. This means that Luke itself controls how the transcription is hidden (currently, it simply doesn’t render the chat for that purpose, which is why the chat component looks like in the image above).

I chose this approach because I think it’s preferable to handle this behavior within Luke’s internals rather than overriding it through CSS.
 
<img width="2541" height="282" alt="image" src="https://github.com/user-attachments/assets/6dba734a-f0e0-4e89-b9de-204256beeb94" />
