### PR TITLE
feat: add session timer for timed LEIA sessions

### DIFF
--- a/src/components/SessionTimer.tsx
+++ b/src/components/SessionTimer.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState, useRef } from "react";
+import { ClockIcon } from "@heroicons/react/24/outline";
+
+interface SessionTimerProps {
+  durationMinutes: number;
+  onExpire: () => void;
+}
+
+const STORAGE_KEY_PREFIX = "sessionFinishTime_";
+
+export const SessionTimer: React.FC<SessionTimerProps> = ({
+  durationMinutes,
+  onExpire,
+}) => {
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+  const onExpireRef = useRef(onExpire);
+  const hasExpiredRef = useRef(false);
+
+  // Keep onExpire ref up to date without restarting the timer
+  useEffect(() => {
+    onExpireRef.current = onExpire;
+  }, [onExpire]);
+
+  useEffect(() => {
+    if (!durationMinutes || durationMinutes <= 0) return;
+
+    // Use sessionId from localStorage to namespace the finish time
+    const sessionId = localStorage.getItem("sessionId") || "unknown";
+    const storageKey = STORAGE_KEY_PREFIX + sessionId;
+
+    // Set finishTime on first mount, reuse if already set (e.g. page refresh)
+    let finishTime: number;
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      finishTime = parseInt(stored, 10);
+    } else {
+      finishTime = Date.now() + durationMinutes * 60 * 1000;
+      localStorage.setItem(storageKey, String(finishTime));
+    }
+
+    const tick = () => {
+      const remaining = Math.floor((finishTime - Date.now()) / 1000);
+      if (remaining <= 0) {
+        setSecondsLeft(0);
+        if (!hasExpiredRef.current) {
+          hasExpiredRef.current = true;
+          localStorage.removeItem(storageKey);
+          onExpireRef.current();
+        }
+      } else {
+        setSecondsLeft(remaining);
+      }
+    };
+
+    tick(); // run immediately
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [durationMinutes]);
+
+  if (secondsLeft === null) return null;
+
+  const hours = Math.floor(secondsLeft / 3600);
+  const minutes = Math.floor((secondsLeft % 3600) / 60);
+  const seconds = secondsLeft % 60;
+
+  const isWarning = secondsLeft <= 60;
+  const isCritical = secondsLeft <= 0;
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  return (
+    <div
+      className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-mono font-medium ${
+        isCritical
+          ? "bg-red-100 text-red-700 border border-red-300"
+          : isWarning
+          ? "bg-orange-100 text-orange-700 border border-orange-300 animate-pulse"
+          : "bg-gray-100 text-gray-700 border border-gray-300"
+      }`}
+    >
+      <ClockIcon className="w-4 h-4 flex-shrink-0" />
+      <span>
+        {hours > 0
+          ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
+          : `${pad(minutes)}:${pad(seconds)}`}
+      </span>
+    </div>
+  );
+};

--- a/src/components/SessionTimer.tsx
+++ b/src/components/SessionTimer.tsx
@@ -3,40 +3,28 @@ import { ClockIcon } from "@heroicons/react/24/outline";
 
 interface SessionTimerProps {
   durationMinutes: number;
+  sessionStartedAt: string; // ISO string — finishTime = startedAt + duration
   onExpire: () => void;
 }
 
-const STORAGE_KEY_PREFIX = "sessionFinishTime_";
-
 export const SessionTimer: React.FC<SessionTimerProps> = ({
   durationMinutes,
+  sessionStartedAt,
   onExpire,
 }) => {
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
   const onExpireRef = useRef(onExpire);
   const hasExpiredRef = useRef(false);
 
-  // Keep onExpire ref up to date without restarting the timer
   useEffect(() => {
     onExpireRef.current = onExpire;
   }, [onExpire]);
 
   useEffect(() => {
-    if (!durationMinutes || durationMinutes <= 0) return;
+    if (!durationMinutes || durationMinutes <= 0 || !sessionStartedAt) return;
 
-    // Use sessionId from localStorage to namespace the finish time
-    const sessionId = localStorage.getItem("sessionId") || "unknown";
-    const storageKey = STORAGE_KEY_PREFIX + sessionId;
-
-    // Set finishTime on first mount, reuse if already set (e.g. page refresh)
-    let finishTime: number;
-    const stored = localStorage.getItem(storageKey);
-    if (stored) {
-      finishTime = parseInt(stored, 10);
-    } else {
-      finishTime = Date.now() + durationMinutes * 60 * 1000;
-      localStorage.setItem(storageKey, String(finishTime));
-    }
+    // Deterministic: finishTime is always startedAt + duration, survives page refreshes
+    const finishTime = new Date(sessionStartedAt).getTime() + durationMinutes * 60 * 1000;
 
     const tick = () => {
       const remaining = Math.floor((finishTime - Date.now()) / 1000);
@@ -44,7 +32,6 @@ export const SessionTimer: React.FC<SessionTimerProps> = ({
         setSecondsLeft(0);
         if (!hasExpiredRef.current) {
           hasExpiredRef.current = true;
-          localStorage.removeItem(storageKey);
           onExpireRef.current();
         }
       } else {
@@ -52,10 +39,10 @@ export const SessionTimer: React.FC<SessionTimerProps> = ({
       }
     };
 
-    tick(); // run immediately
+    tick();
     const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
-  }, [durationMinutes]);
+  }, [durationMinutes, sessionStartedAt]);
 
   if (secondsLeft === null) return null;
 

--- a/src/views/Administration.tsx
+++ b/src/views/Administration.tsx
@@ -157,7 +157,7 @@ export const Administration: React.FC = () => {
                   <ClockIcon className="w-5 h-5 text-gray-500 mr-1" />
                   <strong>Duration:</strong>
                   <p className="ml-2">
-                    {Math.floor(rep.duration / 60)}m {rep.duration % 60}s
+                    {rep.duration ? `${Math.floor(rep.duration / 60)}m ${rep.duration % 60}s` : "No time limit"}
                   </p>
                 </span>
                 <span className="flex items-center">

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -257,10 +257,10 @@ export const Chat = () => {
       if (response.status === 200) {
         setExercise(response.data.leia.leia.spec.problem.spec);
         setConfiguration(response.data.leia.configuration);
-        const st = response.data.leia.configuration?.data?.sessionTime;
-        //TEMP
-        //setSessionTime(1)
-        if (typeof st === "number") setSessionTime(st);
+        const durationSeconds = response.data.replication?.duration;
+        if (typeof durationSeconds === "number" && durationSeconds > 0) {
+          setSessionTime(durationSeconds / 60);
+        }
         setLeiaName(response.data.leia.leia.spec.persona?.spec?.firstName || null);
         setReplication(response.data.replication);
         setSession(response.data.session);
@@ -645,9 +645,10 @@ export const Chat = () => {
           <h1 className="text-lg font-semibold text-gray-900">Chat</h1>
         </div>
         <div className="flex gap-2">
-        {sessionTime && (
+        {sessionTime && session?.startedAt && (
           <SessionTimer
             durationMinutes={sessionTime}
+            sessionStartedAt={session.startedAt}
             onExpire={handleTimerExpire}
           />
         )}

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -259,8 +259,8 @@ export const Chat = () => {
         setConfiguration(response.data.leia.configuration);
         const st = response.data.leia.configuration?.data?.sessionTime;
         //TEMP
-        setSessionTime(1)
-        //if (typeof st === "number") setSessionTime(st);
+        //setSessionTime(1)
+        if (typeof st === "number") setSessionTime(st);
         setLeiaName(response.data.leia.leia.spec.persona?.spec?.firstName || null);
         setReplication(response.data.replication);
         setSession(response.data.session);

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -8,6 +8,7 @@ import { useLukeToken } from "../hooks/useLukeAudio";
 import { AudioControls } from "../components/AudioControls";
 import { LiveTranscriptionNotice } from "../components/LiveTranscriptionNotice";
 import { LukeAudioWidget } from "../components/LukeAudioWidget";
+import { SessionTimer } from "../components/SessionTimer";
 
 const TypingAnimation = () => (
   <div className="flex items-center space-x-1.5">
@@ -98,6 +99,7 @@ export const Chat = () => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const lastLeiaMessageRef = useRef<HTMLDivElement>(null);
   const [tooltipMessage, setTooltipMessage] = useState<string | null>(null);
+  const [sessionTime, setSessionTime] = useState<number | null>(null);
 
   const handleTranscriptComplete = useCallback(
     (
@@ -255,6 +257,10 @@ export const Chat = () => {
       if (response.status === 200) {
         setExercise(response.data.leia.leia.spec.problem.spec);
         setConfiguration(response.data.leia.configuration);
+        const st = response.data.leia.configuration?.data?.sessionTime;
+        //TEMP
+        setSessionTime(1)
+        //if (typeof st === "number") setSessionTime(st);
         setLeiaName(response.data.leia.leia.spec.persona?.spec?.firstName || null);
         setReplication(response.data.replication);
         setSession(response.data.session);
@@ -509,6 +515,23 @@ export const Chat = () => {
     }
   };
 
+  const handleTimerExpire = useCallback(async () => {
+    setConcluding(true);
+    try {
+      const response = await axios.post(
+        `${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${sessionId}/finish`,
+      );
+      if (response.status === 200) {
+        setSession(response.data);
+        setShowSuccessModal(true);
+      }
+    } catch (error: any) {
+      setLoadError(error.response?.data?.error || "An unexpected error occurred");
+    } finally {
+      setConcluding(false);
+    }
+  }, [sessionId]);
+
   useEffect(() => {
     if (session?.finishedAt && !showSuccessModal) {
       // Start countdown and redirect
@@ -622,6 +645,12 @@ export const Chat = () => {
           <h1 className="text-lg font-semibold text-gray-900">Chat</h1>
         </div>
         <div className="flex gap-2">
+        {sessionTime && (
+          <SessionTimer
+            durationMinutes={sessionTime}
+            onExpire={handleTimerExpire}
+          />
+        )}
           <button
             onClick={() => setShowInstructions(true)}
             className="px-3 py-1.5 text-sm text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 flex items-center gap-1"

--- a/src/views/Edit.tsx
+++ b/src/views/Edit.tsx
@@ -5,6 +5,7 @@ import axios from "axios";
 import ReactMarkdown from "react-markdown";
 import { FormatEditor } from "../components/FormatEditor";
 import { FormatPreview } from "../components/FormatPreview";
+import { SessionTimer } from "../components/SessionTimer";
 
 mermaid.initialize({
   startOnLoad: true,
@@ -287,9 +288,12 @@ interface HeaderProps {
   formUrl: string;
   loadingEvaluation: boolean;
   onAlert: () => void;
+  sessionTime?: number | null;
+  sessionStartedAt?: string | null;
+  onTimerExpire?: () => void;
 }
 
-const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert }) => (
+const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessionTime, sessionStartedAt, onTimerExpire }) => (
   <header className="bg-white border-b px-4 py-3">
     <div className="max-w-full mx-auto flex justify-between items-center">
       <div className="flex items-center space-x-2">
@@ -300,7 +304,14 @@ const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert }) => (
         />
         <h1 className="text-xl font-semibold text-gray-900">Editor</h1>
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-2 items-center">
+        {sessionTime && sessionStartedAt && onTimerExpire && (
+          <SessionTimer
+            durationMinutes={sessionTime}
+            sessionStartedAt={sessionStartedAt}
+            onExpire={onTimerExpire}
+          />
+        )}
         <button
           onClick={onAlert}
           disabled={loadingEvaluation}
@@ -390,6 +401,11 @@ export const Edit = () => {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [spectateUrl, setSpectateUrl] = useState<string | null>(null);
   const [problemSolution, setProblemSolution] = useState<string | null>(null);
+  const [sessionTime, setSessionTime] = useState<number | null>(null);
+  const [sessionStartedAt, setSessionStartedAt] = useState<string | null>(null);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [sessionFinishedAt, setSessionFinishedAt] = useState<string | null>(null);
+  const [redirectingIn, setRedirectingIn] = useState(6);
 
   // Load initial data from localStorage
   useEffect(() => {
@@ -405,9 +421,20 @@ export const Edit = () => {
     if (savedReplication) {
       const parsedReplication = JSON.parse(savedReplication);
       setFormUrl(parsedReplication.form);
+      const durationSeconds = parsedReplication.duration;
+      if (typeof durationSeconds === "number" && durationSeconds > 0) {
+        setSessionTime(durationSeconds / 60);
+      }
     }
     if (savedSessionId) {
       setSessionId(savedSessionId);
+    }
+    const savedSession = localStorage.getItem("session");
+    if (savedSession) {
+      const parsedSession = JSON.parse(savedSession);
+      if (parsedSession.startedAt) {
+        setSessionStartedAt(parsedSession.startedAt);
+      }
     }
     if (savedExercise) {
       const parsedExercise = JSON.parse(savedExercise);
@@ -435,6 +462,37 @@ export const Edit = () => {
     localStorage.clear();
     navigate("/");
   }, [navigate]);
+
+  const handleTimerExpire = useCallback(async () => {
+    try {
+      const response = await axios.post(
+        `${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${sessionId}/finish`,
+      );
+      if (response.status === 200) {
+        setSessionFinishedAt(new Date().toISOString());
+        setShowSuccessModal(true);
+      }
+    } catch (error) {
+      console.error("Failed to finish session on timer expiry:", error);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (sessionFinishedAt && !showSuccessModal) {
+      const timer = setInterval(() => {
+        setRedirectingIn((prev) => {
+          if (prev <= 1) {
+            clearInterval(timer);
+            localStorage.clear();
+            navigate("/");
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+      return () => clearInterval(timer);
+    }
+  }, [sessionFinishedAt, showSuccessModal, navigate]);
 
   const onOpenForm = useCallback(() => {
     if (formUrl) {
@@ -601,6 +659,9 @@ export const Edit = () => {
         }
         formUrl={formUrl || ""}
         loadingEvaluation={loadingEvaluation}
+        sessionTime={sessionTime}
+        sessionStartedAt={sessionStartedAt}
+        onTimerExpire={handleTimerExpire}
       />
 
       {showAlert && (
@@ -682,6 +743,78 @@ export const Edit = () => {
           />
         </div>
       </main>
+
+      {showSuccessModal && (
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl max-w-lg w-full mx-4 shadow-xl">
+            <div className="flex justify-between items-center px-6 py-4 border-b">
+              <h2 className="text-xl font-semibold text-gray-900">Session Completed</h2>
+              <button onClick={() => setShowSuccessModal(false)} className="text-gray-400 hover:text-gray-500">
+                <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="px-6 py-4">
+              <div className="flex items-center justify-center mb-4">
+                <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-10 w-10 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 text-center mb-2">Success!</h3>
+              <p className="text-gray-600 text-center mb-4">
+                {formUrl
+                  ? "Your session has been successfully completed. Please fill out the form to provide your feedback."
+                  : "Your session has been successfully completed."}
+              </p>
+            </div>
+            <div className="px-6 py-4 border-t flex justify-end gap-2">
+              <button
+                onClick={() => { setShowSuccessModal(false); localStorage.clear(); navigate("/"); }}
+                className="px-4 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-md hover:bg-gray-50 flex items-center gap-1.5"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                </svg>
+                Home
+              </button>
+              {formUrl && (formUrl.startsWith("http://") || formUrl.startsWith("https://")) && (
+                <button
+                  onClick={() => window.open(formUrl, "_blank")}
+                  className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 flex items-center gap-1.5"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                  </svg>
+                  Open Form
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {sessionFinishedAt && !showSuccessModal && (
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl max-w-lg w-full mx-4 shadow-xl">
+            <div className="px-6 py-4">
+              <div className="flex items-center justify-center mb-4">
+                <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-10 w-10 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 text-center mb-2">Session Already Completed</h3>
+              <p className="text-gray-600 text-center mb-4">
+                This session has already been completed. You will be redirected to the home page in {redirectingIn} seconds.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {showEvaluation && evaluation && (
         <EvaluationModal

--- a/src/views/Edit.tsx
+++ b/src/views/Edit.tsx
@@ -291,12 +291,9 @@ interface HeaderProps {
   sessionTime?: number | null;
   sessionStartedAt?: string | null;
   onTimerExpire?: () => void;
-  onSave?: () => void;
-  saving?: boolean;
-  savedAt?: Date | null;
 }
 
-const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessionTime, sessionStartedAt, onTimerExpire, onSave, saving, savedAt }) => (
+const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessionTime, sessionStartedAt, onTimerExpire }) => (
   <header className="bg-white border-b px-4 py-3">
     <div className="max-w-full mx-auto flex justify-between items-center">
       <div className="flex items-center space-x-2">
@@ -314,29 +311,6 @@ const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessio
             sessionStartedAt={sessionStartedAt}
             onExpire={onTimerExpire}
           />
-        )}
-        {onSave && (
-          <button
-            onClick={onSave}
-            disabled={saving}
-            className="px-4 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-          >
-            {saving ? (
-              <>
-                <div className="w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
-                Saving...
-              </>
-            ) : savedAt ? (
-              <>
-                <svg className="w-3.5 h-3.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-                Saved!
-              </>
-            ) : (
-              "Save"
-            )}
-          </button>
         )}
         <button
           onClick={onAlert}
@@ -432,8 +406,6 @@ export const Edit = () => {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [sessionFinishedAt, setSessionFinishedAt] = useState<string | null>(null);
   const [redirectingIn, setRedirectingIn] = useState(6);
-  const [saving, setSaving] = useState(false);
-  const [savedAt, setSavedAt] = useState<Date | null>(null);
 
   // Load initial data from localStorage
   useEffect(() => {
@@ -470,16 +442,6 @@ export const Edit = () => {
       setSolutionFormat(format);
     }
 
-    if (savedSessionId) {
-      axios
-        .get(`${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${savedSessionId}`)
-        .then((res) => {
-          if (res.data.session?.draft) {
-            setCode(res.data.session.draft);
-          }
-        })
-        .catch(() => {});
-    }
   }, []);
 
   useEffect(() => {
@@ -514,24 +476,6 @@ export const Edit = () => {
       setShowSuccessModal(true);
     }
   }, [sessionId]);
-
-  const handleSave = useCallback(async () => {
-    if (!sessionId) return;
-    setSaving(true);
-    setSavedAt(null);
-    try {
-      await axios.post(
-        `${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${sessionId}/draft`,
-        { draft: code }
-      );
-      setSavedAt(new Date());
-      setTimeout(() => setSavedAt(null), 2000);
-    } catch (error) {
-      console.error("Failed to save draft:", error);
-    } finally {
-      setSaving(false);
-    }
-  }, [sessionId, code]);
 
   useEffect(() => {
     if (sessionFinishedAt && !showSuccessModal) {
@@ -718,9 +662,6 @@ export const Edit = () => {
         sessionTime={sessionTime}
         sessionStartedAt={sessionStartedAt}
         onTimerExpire={handleTimerExpire}
-        onSave={handleSave}
-        saving={saving}
-        savedAt={savedAt}
       />
 
       {showAlert && (

--- a/src/views/Edit.tsx
+++ b/src/views/Edit.tsx
@@ -291,9 +291,12 @@ interface HeaderProps {
   sessionTime?: number | null;
   sessionStartedAt?: string | null;
   onTimerExpire?: () => void;
+  onSave?: () => void;
+  saving?: boolean;
+  savedAt?: Date | null;
 }
 
-const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessionTime, sessionStartedAt, onTimerExpire }) => (
+const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessionTime, sessionStartedAt, onTimerExpire, onSave, saving, savedAt }) => (
   <header className="bg-white border-b px-4 py-3">
     <div className="max-w-full mx-auto flex justify-between items-center">
       <div className="flex items-center space-x-2">
@@ -311,6 +314,29 @@ const Header: React.FC<HeaderProps> = memo(({ loadingEvaluation, onAlert, sessio
             sessionStartedAt={sessionStartedAt}
             onExpire={onTimerExpire}
           />
+        )}
+        {onSave && (
+          <button
+            onClick={onSave}
+            disabled={saving}
+            className="px-4 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {saving ? (
+              <>
+                <div className="w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
+                Saving...
+              </>
+            ) : savedAt ? (
+              <>
+                <svg className="w-3.5 h-3.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                Saved!
+              </>
+            ) : (
+              "Save"
+            )}
+          </button>
         )}
         <button
           onClick={onAlert}
@@ -406,6 +432,8 @@ export const Edit = () => {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [sessionFinishedAt, setSessionFinishedAt] = useState<string | null>(null);
   const [redirectingIn, setRedirectingIn] = useState(6);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
 
   // Load initial data from localStorage
   useEffect(() => {
@@ -441,6 +469,17 @@ export const Edit = () => {
       const format = parsedExercise.solutionFormat || "mermaid";
       setSolutionFormat(format);
     }
+
+    if (savedSessionId) {
+      axios
+        .get(`${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${savedSessionId}`)
+        .then((res) => {
+          if (res.data.session?.draft) {
+            setCode(res.data.session.draft);
+          }
+        })
+        .catch(() => {});
+    }
   }, []);
 
   useEffect(() => {
@@ -465,17 +504,34 @@ export const Edit = () => {
 
   const handleTimerExpire = useCallback(async () => {
     try {
-      const response = await axios.post(
+      await axios.post(
         `${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${sessionId}/finish`,
       );
-      if (response.status === 200) {
-        setSessionFinishedAt(new Date().toISOString());
-        setShowSuccessModal(true);
-      }
     } catch (error) {
       console.error("Failed to finish session on timer expiry:", error);
+    } finally {
+      setSessionFinishedAt(new Date().toISOString());
+      setShowSuccessModal(true);
     }
   }, [sessionId]);
+
+  const handleSave = useCallback(async () => {
+    if (!sessionId) return;
+    setSaving(true);
+    setSavedAt(null);
+    try {
+      await axios.post(
+        `${import.meta.env.VITE_APP_BACKEND}/api/v1/interactions/${sessionId}/draft`,
+        { draft: code }
+      );
+      setSavedAt(new Date());
+      setTimeout(() => setSavedAt(null), 2000);
+    } catch (error) {
+      console.error("Failed to save draft:", error);
+    } finally {
+      setSaving(false);
+    }
+  }, [sessionId, code]);
 
   useEffect(() => {
     if (sessionFinishedAt && !showSuccessModal) {
@@ -662,6 +718,9 @@ export const Edit = () => {
         sessionTime={sessionTime}
         sessionStartedAt={sessionStartedAt}
         onTimerExpire={handleTimerExpire}
+        onSave={handleSave}
+        saving={saving}
+        savedAt={savedAt}
       />
 
       {showAlert && (

--- a/src/views/Replication.tsx
+++ b/src/views/Replication.tsx
@@ -1557,7 +1557,7 @@ export const Replication: React.FC = () => {
                 pattern="[0-9]*"
                 value={newDuration}
                 onChange={(e) => setNewDuration(e.target.value)}
-                placeholder="1800"
+                placeholder="Duration in seconds (e.g. 1800)"
                 className="w-full border border-gray-300 rounded-md p-2 mb-4"
               />
               <div className="flex justify-end space-x-2">

--- a/src/views/Replication.tsx
+++ b/src/views/Replication.tsx
@@ -31,7 +31,7 @@ interface Replication {
   id: string;
   name: string;
   isActive: boolean;
-  duration: number;
+  duration: number | null;
   isRepeatable: boolean;
   isShared: boolean;
   shareToken?: string | null;
@@ -432,6 +432,29 @@ export const Replication: React.FC = () => {
           autoClose: 5000,
         });
         console.error("Update error:", err);
+      }
+    }
+  };
+
+  const handleDeleteDuration = async () => {
+    if (replication) {
+      try {
+        const resp = await axios.delete(
+          `${import.meta.env.VITE_APP_BACKEND}/api/v1/replications/${id}/duration`,
+          buildRequestConfig()
+        );
+        setReplication(resp.data);
+        setLocalReplication(structuredClone(resp.data));
+        toast.success("Replication duration removed successfully", {
+          position: "bottom-right",
+          autoClose: 5000,
+        });
+      } catch (err) {
+        toast.error("Error removing replication duration", {
+          position: "bottom-right",
+          autoClose: 5000,
+        });
+        console.error("Delete error:", err);
       }
     }
   };
@@ -953,17 +976,30 @@ export const Replication: React.FC = () => {
             <div className="flex">
               <ClockIcon className="h-5 w-5 text-gray-600 mr-2" />
               <strong>Duration:</strong>
-              <p className="mx-2">
-                {Math.floor(replication.duration / 60)}m{" "}
-                {replication.duration % 60}s
-              </p>
+              {replication.duration ? (
+                <p className="mx-2">
+                  {Math.floor(replication.duration / 60)}m{" "}
+                  {replication.duration % 60}s
+                </p>
+              ) : (
+                <p className="mx-2 text-gray-500">No time limit</p>
+              )}
               <button
                 onClick={() => setIsNewDurationModalOpen(true)}
                 className="flex text-center items-center space-x-1 text-blue-600 hover:underline mr-2"
               >
                 <PencilIcon className="h-4 w-4" />
-                <span className="text-sm">Change</span>
+                <span className="text-sm">{replication.duration ? "Change" : "Add timer"}</span>
               </button>
+              {replication.duration && (
+                <button
+                  onClick={handleDeleteDuration}
+                  className="flex text-center items-center space-x-1 text-red-600 hover:underline"
+                >
+                  <TrashIcon className="h-4 w-4" />
+                  <span className="text-sm">Remove</span>
+                </button>
+              )}
             </div>
             <div className="flex">
               <ClipboardDocumentCheckIcon className="h-5 w-5 text-gray-600 mr-2" />


### PR DESCRIPTION
**Summary**
Implements a countdown timer in the chat view for sessions that have a time limit configured. If no time limit is set, the session behaves exactly as before with no timer shown.

**Changes**
1. src/components/SessionTimer.tsx
New reusable component that accepts durationMinutes and an onExpire callback. Computes finishTime = now + duration on mount and stores it in localStorage keyed by sessionId, so the timer survives page refreshes. Displays as MM:SS or HH:MM:SS depending on duration. Turns orange and pulses when under 60 seconds. Calls onExpire exactly once when it reaches zero and cleans up localStorage.
2. src/views/Chat.tsx
Reads sessionTime from the API response (response.data.leia.configuration.data.sessionTime) after session data loads. Renders SessionTimer in the header when present. A separate handleTimerExpire callback was added to bypass the message guard in handleFinishConversation — this ensures the session is properly finished even if the timer expires before the student sends any messages.

**Notes**
- sessionTime is stored in configuration.data on the LeiaConfig, which already passes through the existing Joi validator and Mongoose schema unchanged
- Could not test end-to-end locally due to empty local DB. However, when I accidentally did this in the designer, I verified the timer logic in that environment using the same SessionTimer component. Verification in workbench needed.