### PR TITLE
feat(admin): API Keys page in MUI + admin sidebar (AdminLayout)

### DIFF
--- a/src/components/apikeys/ApiKeyCard.tsx
+++ b/src/components/apikeys/ApiKeyCard.tsx
@@ -1,157 +1,367 @@
 import React from "react";
 import {
-  PencilIcon,
-  TrashIcon,
-  LinkIcon,
-  CubeTransparentIcon,
-  StarIcon as StarSolidIcon
-} from "@heroicons/react/24/solid";
-import { StarIcon as StarOutlineIcon } from "@heroicons/react/24/outline";
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Link as MuiLink,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
+import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderOutlinedIcon from "@mui/icons-material/StarBorderOutlined";
+import StatusDot from "../admin/StatusDot";
 import { ApiKey } from "../../models/ApiKeys"; // Asegúrate de que esta ruta sea correcta en tu proyecto
 
 interface ApiKeyCardProps {
   apiKey: ApiKey;
-  userRole: string|undefined;
+  userRole: string | undefined;
   onEdit: () => void;
   onDelete: () => void;
   onToggleDefault?: (apiKey: ApiKey) => void;
   isSaving?: boolean;
 }
 
-export const ApiKeyCard: React.FC<ApiKeyCardProps> = ({ apiKey, onEdit, userRole,onDelete, onToggleDefault, isSaving = false }) => {
+const MetaRow: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}> = ({ icon, label, children }) => (
+  <Stack direction="row" spacing={1.5} alignItems="flex-start">
+    <Box sx={{ color: "text.disabled", display: "flex", mt: 0.25 }}>{icon}</Box>
+    <Box sx={{ minWidth: 0 }}>
+      <Typography variant="overline" sx={{ display: "block" }}>
+        {label}
+      </Typography>
+      <Box sx={{ mt: 0.25, minWidth: 0 }}>{children}</Box>
+    </Box>
+  </Stack>
+);
 
+export const ApiKeyCard: React.FC<ApiKeyCardProps> = ({
+  apiKey,
+  onEdit,
+  userRole,
+  onDelete,
+  onToggleDefault,
+  isSaving = false,
+}) => {
   const handleToggleDefault = () => {
     if (onToggleDefault) {
       onToggleDefault(apiKey);
       return;
     }
   };
+
+  const canManage = !apiKey?.isSystemApiKey || (userRole && userRole === "admin");
+
   return (
-    <div className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 border border-gray-200 p-6 flex flex-col">
+    <Card
+      variant="outlined"
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        borderColor: "divider",
+        transition: "box-shadow 0.2s ease",
+        "&:hover": { boxShadow: 2 },
+      }}
+    >
+      <CardContent
+        sx={{
+          p: 3,
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          "&:last-child": { pb: 3 },
+        }}
+      >
+        {/* --- CABECERA --- */}
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="flex-start"
+          spacing={2}
+          sx={{ mb: 2.5 }}
+        >
+          <Box sx={{ minWidth: 0, overflow: "hidden" }}>
+            <Typography
+              variant="h6"
+              title={apiKey.description}
+              sx={{
+                fontWeight: 700,
+                color: "text.primary",
+                mb: 1,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {apiKey.description}
+            </Typography>
 
-      {/* --- CABECERA --- */}
-      <div className="flex justify-between items-start mb-5">
-        <div className="overflow-hidden pr-4">
-          <h3 className="text-xl font-bold text-gray-800 mb-2 truncate" title={apiKey.description}>
-            {apiKey.description}
-          </h3>
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              flexWrap="wrap"
+              useFlexGap
+            >
+              <Chip
+                size="small"
+                icon={
+                  <StatusDot color={apiKey.isActive ? "success" : "neutral"} />
+                }
+                label={apiKey.isActive ? "Active" : "Inactive"}
+                sx={{
+                  height: 22,
+                  fontSize: 11,
+                  fontWeight: 500,
+                  bgcolor: apiKey.isActive
+                    ? "rgba(22,163,74,0.08)"
+                    : "surfaces.subtle",
+                  color: apiKey.isActive ? "success.main" : "text.secondary",
+                  "& .MuiChip-icon": { ml: 1, mr: -0.25 },
+                }}
+              />
 
-          <div className="flex items-center space-x-2">
-            <span className={`inline-flex items-center px-2 py-1 rounded text-xs font-medium ${
-              apiKey.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-600'
-            }`}>
-              {apiKey.isActive ? (
-                <span className="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
-              ) : (
-                <span className="w-2 h-2 bg-gray-400 rounded-full mr-2"></span>
+              {apiKey.isDefault && (
+                <Chip
+                  size="small"
+                  label="Default"
+                  sx={{
+                    height: 22,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: "0.04em",
+                    textTransform: "uppercase",
+                    bgcolor: "surfaces.accent",
+                    color: "primary.dark",
+                  }}
+                />
               )}
-              {apiKey.isActive ? 'Active' : 'Inactive'}
-            </span>
 
-            {apiKey.isDefault && (
-              <span className="bg-blue-100 text-blue-800 text-[10px] font-bold px-2.5 py-1 rounded uppercase tracking-wide">
-                Default
+              {apiKey.isSystemApiKey && (
+                <Chip
+                  size="small"
+                  label="System"
+                  sx={{
+                    height: 22,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: "0.04em",
+                    textTransform: "uppercase",
+                    bgcolor: "surfaces.subtle",
+                    color: "warning.main",
+                  }}
+                />
+              )}
+            </Stack>
+          </Box>
+
+          <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+            <Tooltip
+              title={apiKey.isDefault ? "Unmark Default" : "Mark as Default"}
+            >
+              <span>
+                <IconButton
+                  onClick={handleToggleDefault}
+                  disabled={isSaving}
+                  size="small"
+                  sx={{
+                    border: "1px solid",
+                    borderColor: "divider",
+                    borderRadius: 1.5,
+                    color: "text.secondary",
+                    bgcolor: "background.paper",
+                    "&:hover": {
+                      color: "warning.main",
+                      borderColor: "warning.main",
+                      bgcolor: "rgba(217,119,6,0.06)",
+                    },
+                  }}
+                >
+                  {isSaving ? (
+                    <CircularProgress size={20} sx={{ color: "text.secondary" }} />
+                  ) : apiKey.isDefault ? (
+                    <StarIcon sx={{ fontSize: 20, color: "warning.main" }} />
+                  ) : (
+                    <StarBorderOutlinedIcon
+                      sx={{ fontSize: 20, color: "text.disabled" }}
+                    />
+                  )}
+                </IconButton>
               </span>
-            )}
+            </Tooltip>
 
-            {apiKey.isSystemApiKey && (
-              <span className="bg-gray-100 text-yellow-800 text-[10px] font-bold px-2.5 py-1 rounded uppercase tracking-wide">
-                System
-              </span>
+            {canManage && (
+              <>
+                <Tooltip title="Edit API Key">
+                  <IconButton
+                    onClick={onEdit}
+                    size="small"
+                    sx={{
+                      border: "1px solid",
+                      borderColor: "divider",
+                      borderRadius: 1.5,
+                      color: "text.secondary",
+                      bgcolor: "background.paper",
+                      "&:hover": {
+                        color: "primary.main",
+                        borderColor: "primary.main",
+                        bgcolor: "surfaces.accent",
+                      },
+                    }}
+                  >
+                    <EditOutlinedIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete API Key">
+                  <IconButton
+                    onClick={onDelete}
+                    size="small"
+                    sx={{
+                      border: "1px solid",
+                      borderColor: "divider",
+                      borderRadius: 1.5,
+                      color: "text.secondary",
+                      bgcolor: "background.paper",
+                      "&:hover": {
+                        color: "error.main",
+                        borderColor: "error.main",
+                        bgcolor: "rgba(220,38,38,0.06)",
+                      },
+                    }}
+                  >
+                    <DeleteOutlinedIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </Tooltip>
+              </>
             )}
-          </div>
-        </div>
+          </Stack>
+        </Stack>
 
-        <div className="flex space-x-2 flex-shrink-0">
-          <button
-            onClick={handleToggleDefault}
-            title={apiKey.isDefault ? "Unmark Default" : "Mark as Default"}
-            disabled={isSaving}
-            className={`p-2 bg-white border border-gray-200 rounded-lg text-gray-500 transition-all shadow-sm ${isSaving ? 'opacity-60 cursor-not-allowed' : 'hover:text-yellow-600 hover:bg-yellow-50 hover:border-yellow-200'}`}
+        <Divider sx={{ mb: 2.5 }} />
+
+        {/* --- CUERPO (Datos) --- */}
+        <Stack spacing={2.5} sx={{ flex: 1 }}>
+          {/* Valor de la API Key */}
+          <Box>
+            <Typography variant="overline" sx={{ display: "block" }}>
+              API Key Value
+            </Typography>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                mt: 0.75,
+                p: 1.25,
+                borderRadius: 1.5,
+                border: "1px solid",
+                borderColor: "divider",
+                bgcolor: "surfaces.subtle",
+              }}
+            >
+              <Typography
+                className="mono"
+                sx={{
+                  color: "text.primary",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {apiKey.keyValue}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Stack
+            spacing={2}
+            sx={{
+              p: 2,
+              borderRadius: 1.5,
+              border: "1px solid",
+              borderColor: "divider",
+              bgcolor: "surfaces.subtle",
+            }}
           >
-            {isSaving ? (
-              <svg className="animate-spin h-5 w-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-              </svg> // Cambiar por iconos
-            ) : apiKey.isDefault ? (
-              <StarSolidIcon className="h-5 w-5 text-yellow-500" />
-            ) : (
-              <StarOutlineIcon className="h-5 w-5 text-gray-400" />
-            )}
-          </button>
-
-          {(!apiKey?.isSystemApiKey|| (userRole && userRole === 'admin')) && (
-            <>
-              <button
-                onClick={onEdit}
-                title="Edit API Key"
-                className="p-2 bg-white border border-gray-200 rounded-lg text-gray-500 hover:text-blue-600 hover:bg-blue-50 hover:border-blue-200 transition-all shadow-sm"
+            <MetaRow
+              icon={<ViewInArOutlinedIcon sx={{ fontSize: 20 }} />}
+              label="API Key Provider"
+            >
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 600,
+                  color: "text.primary",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
               >
-                <PencilIcon className="h-5 w-5" />
-              </button>
-              <button
-                onClick={onDelete}
-                title="Delete API Key"
-                className="p-2 bg-white border border-gray-200 rounded-lg text-gray-500 hover:text-red-600 hover:bg-red-50 hover:border-red-200 transition-all shadow-sm"
+                {apiKey.provider}
+              </Typography>
+            </MetaRow>
+
+            {apiKey.baseUrl && (
+              <MetaRow
+                icon={<LinkOutlinedIcon sx={{ fontSize: 20 }} />}
+                label="Base URL"
               >
-                <TrashIcon className="h-5 w-5" />
-              </button>
-            </>
-          )}
-        </div>
-      </div>
-
-      <hr className="border-gray-100 mb-5" />
-
-      {/* --- CUERPO (Datos) --- */}
-      <div className="flex-1 space-y-5">
-
-        {/* Valor de la API Key */}
-        <div>
-          <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">API Key Value</label>
-          <div className="flex items-center justify-between mt-1.5 bg-gray-50 border border-gray-200 rounded-lg p-2.5">
-
-            <span className="text-sm font-mono text-gray-800 truncate">
-              {apiKey.keyValue}
-            </span>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 gap-4 bg-gray-50/50 rounded-lg p-4 border border-gray-100">
-          <div className="flex items-start space-x-3">
-            <CubeTransparentIcon className="h-5 w-5 text-gray-400 mt-0.5" />
-            <div className="overflow-hidden">
-              <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">API Key Provider</p>
-              <p className="text-sm text-gray-800 font-semibold mt-0.5 truncate">{apiKey.provider}</p>
-            </div>
-          </div>
-
-          {apiKey.baseUrl &&(
-            <div className="flex items-start space-x-3">
-              <LinkIcon className="h-5 w-5 text-gray-400 mt-0.5" />
-              <div className="overflow-hidden">
-                <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Base URL</p>
-                <a href={apiKey.baseUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 truncate hover:underline mt-0.5 block">
+                <MuiLink
+                  href={apiKey.baseUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="hover"
+                  sx={{
+                    display: "block",
+                    fontSize: 14,
+                    color: "primary.main",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
                   {apiKey.baseUrl}
-                </a>
-              </div>
-            </div>
-          )}
+                </MuiLink>
+              </MetaRow>
+            )}
 
-          {apiKey.managementUrl && (
-            <div className="flex items-start space-x-3">
-              <LinkIcon className="h-5 w-5 text-gray-400 mt-0.5" />
-              <div className="overflow-hidden">
-                <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Management URL</p>
-                <a href={apiKey.managementUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 truncate hover:underline mt-0.5 block">
+            {apiKey.managementUrl && (
+              <MetaRow
+                icon={<LinkOutlinedIcon sx={{ fontSize: 20 }} />}
+                label="Management URL"
+              >
+                <MuiLink
+                  href={apiKey.managementUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="hover"
+                  sx={{
+                    display: "block",
+                    fontSize: 14,
+                    color: "primary.main",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
                   {apiKey.managementUrl}
-                </a>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+                </MuiLink>
+              </MetaRow>
+            )}
+          </Stack>
+        </Stack>
+      </CardContent>
+    </Card>
   );
 };

--- a/src/components/apikeys/ApiKeyFormModal.tsx
+++ b/src/components/apikeys/ApiKeyFormModal.tsx
@@ -1,4 +1,24 @@
 import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import { ApiKey } from "../../models/ApiKeys";
 import { useProviders } from "../../hooks/useProviders";
 
@@ -41,8 +61,16 @@ export const ApiKeyFormModal: React.FC<ApiKeyFormModalProps> = ({ isOpen, mode, 
       }
     }
   }, [isOpen, mode, selectedKey]);
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value, type } = e.target;
+  const handleChange = (
+    e:
+      | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+      | SelectChangeEvent
+  ) => {
+    const { name, value, type } = e.target as {
+      name: string;
+      value: string;
+      type?: string;
+    };
 
     if (type === 'checkbox') {
       const checked = (e.target as HTMLInputElement).checked;
@@ -68,117 +96,194 @@ export const ApiKeyFormModal: React.FC<ApiKeyFormModalProps> = ({ isOpen, mode, 
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-lg w-full overflow-hidden flex flex-col max-h-[90vh]">
-        <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
-          <h2 className="text-lg font-bold text-gray-800">
-            {mode === "create" ? "Add New API Key" : "Edit API Key"}
-          </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-          </button>
-        </div>
+    <Dialog open={isOpen} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+        }}
+      >
+        <Typography variant="h6" component="span">
+          {mode === "create" ? "Add New API Key" : "Edit API Key"}
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="Close"
+          size="small"
+          sx={{ color: "text.disabled", "&:hover": { color: "text.secondary" } }}
+        >
+          <CloseIcon sx={{ fontSize: 20 }} />
+        </IconButton>
+      </DialogTitle>
 
-        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto">
-          <div className="p-6 space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Key Name (Description)</label>
-              <input type="text" name="description" value={formData.description || ""} onChange={handleChange} className={`w-full border ${errors.description ? 'border-red-500' : 'border-gray-300'} rounded-md p-2 text-sm focus:ring-blue-500 focus:border-blue-500`} placeholder="e.g. Production Key" required />
-              {errors.description && <p className="text-red-500 text-xs mt-1">{errors.description}</p>}
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">API Key Value</label>
-              <input type="text" name="keyValue" value={formData.keyValue || ""} onChange={handleChange} className={`w-full border ${errors.keyValue ? 'border-red-500' : 'border-gray-300'} rounded-md p-2 text-sm focus:ring-blue-500 focus:border-blue-500 font-mono`} placeholder={mode === "create" ? "sk-..." : "Leave blank to keep current"} required={mode === 'create'} />
-              {errors.keyValue && <p className="text-red-500 text-xs mt-1">{errors.keyValue}</p>}
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">API Key Type</label>
-                <select
+      <Box component="form" id="api-key-form" onSubmit={handleSubmit}>
+        <DialogContent dividers>
+          <Stack spacing={2.5}>
+            <TextField
+              label="Key Name (Description)"
+              name="description"
+              value={formData.description || ""}
+              onChange={handleChange}
+              placeholder="e.g. Production Key"
+              required
+              fullWidth
+              error={!!errors.description}
+              helperText={errors.description}
+            />
+            <TextField
+              label="API Key Value"
+              name="keyValue"
+              value={formData.keyValue || ""}
+              onChange={handleChange}
+              placeholder={mode === "create" ? "sk-..." : "Leave blank to keep current"}
+              required={mode === "create"}
+              fullWidth
+              error={!!errors.keyValue}
+              helperText={errors.keyValue}
+              InputProps={{ sx: { fontFamily: "'JetBrains Mono Variable', ui-monospace, monospace" } }}
+            />
+            <Stack direction="row" spacing={2}>
+              <FormControl
+                fullWidth
+                required
+                error={!!errors.provider}
+                disabled={isLoadingProviders}
+              >
+                <InputLabel id="api-key-provider-label">API Key Type</InputLabel>
+                <Select
+                  labelId="api-key-provider-label"
+                  label="API Key Type"
                   name="provider"
                   value={formData.provider || ""}
                   onChange={handleChange}
-                  className={`w-full border ${errors.provider ? 'border-red-500' : 'border-gray-300'} rounded-md p-2 text-sm focus:ring-blue-500 focus:border-blue-500`}
-                  required
-                  disabled={isLoadingProviders}
+                  displayEmpty
+                  renderValue={(selected) =>
+                    selected
+                      ? (selected as string)
+                      : (
+                        <Typography component="span" sx={{ color: "text.disabled" }}>
+                          {isLoadingProviders ? "Loading providers..." : "Select a provider"}
+                        </Typography>
+                      )
+                  }
                 >
-                  <option value="" disabled>
-                    {isLoadingProviders ? "Loading providers..." : "Select a provider"}
-                  </option>
                   {apiKeysProviderSet.map((provider) => (
-                    <option key={provider} value={provider}>
+                    <MenuItem key={provider} value={provider}>
                       {provider}
-                    </option>
+                    </MenuItem>
                   ))}
-                </select>
-                {errors.provider && <p className="text-red-500 text-xs mt-1">{errors.provider}</p>}
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
-                <select name="isActive" value={formData.isActive ? "Active" : "Inactive"} onChange={handleChange} className="w-full border border-gray-300 rounded-md p-2 text-sm focus:ring-blue-500 focus:border-blue-500">
-                  <option value="Active">Active</option>
-                  <option value="Inactive">Inactive</option>
-                </select>
-              </div>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Base URL<span className="text-gray-400 font-normal">(Required for local providers)</span></label>
-              <input type="url" name="baseUrl" value={formData.baseUrl || ""} onChange={handleChange} className={`w-full border ${errors.baseUrl ? 'border-red-500' : 'border-gray-300'} rounded-md p-2 text-sm focus:ring-blue-500 focus:border-blue-500 text-blue-600`} placeholder="https://..." />
-              {errors.baseUrl && <p className="text-red-500 text-xs mt-1">{errors.baseUrl}</p>}
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Management URL <span className="text-gray-400 font-normal">(Optional)</span></label>
-              <input type="url" name="managementUrl" value={formData.managementUrl || ""} onChange={handleChange} className="w-full border border-gray-300 rounded-md p-2 text-sm focus:ring-blue-500 focus:border-blue-500 text-blue-600" placeholder="https://..." />
-            </div>
+                </Select>
+                {errors.provider && (
+                  <Typography variant="caption" sx={{ color: "error.main", mt: 0.5, ml: 1.75 }}>
+                    {errors.provider}
+                  </Typography>
+                )}
+              </FormControl>
+              <FormControl fullWidth>
+                <InputLabel id="api-key-status-label">Status</InputLabel>
+                <Select
+                  labelId="api-key-status-label"
+                  label="Status"
+                  name="isActive"
+                  value={formData.isActive ? "Active" : "Inactive"}
+                  onChange={handleChange}
+                >
+                  <MenuItem value="Active">Active</MenuItem>
+                  <MenuItem value="Inactive">Inactive</MenuItem>
+                </Select>
+              </FormControl>
+            </Stack>
+            <TextField
+              label="Base URL (Required for local providers)"
+              name="baseUrl"
+              type="url"
+              value={formData.baseUrl || ""}
+              onChange={handleChange}
+              placeholder="https://..."
+              fullWidth
+              error={!!errors.baseUrl}
+              helperText={errors.baseUrl}
+              InputProps={{ sx: { color: "primary.main" } }}
+            />
+            <TextField
+              label="Management URL (Optional)"
+              name="managementUrl"
+              type="url"
+              value={formData.managementUrl || ""}
+              onChange={handleChange}
+              placeholder="https://..."
+              fullWidth
+              InputProps={{ sx: { color: "primary.main" } }}
+            />
             {mode === "create" && (
-              <div className="pt-2 border-t border-gray-100 mt-4">
-                <label className="flex items-center space-x-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    name="isDefault"
-                    checked={!!formData.isDefault}
-                    onChange={handleChange}
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                  />
-                  <span className="text-sm font-medium text-gray-700">
-                    Make this the default API Key
-                  </span>
-                </label>
-                {errors.isDefault && <p className="text-red-500 text-xs mt-1 ml-7">{errors.isDefault}</p>}
-                <p className="text-xs text-gray-500 mt-1 ml-7">
+              <Box sx={{ pt: 1, borderTop: "1px solid", borderColor: "divider" }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="isDefault"
+                      checked={!!formData.isDefault}
+                      onChange={handleChange}
+                      size="small"
+                    />
+                  }
+                  label={
+                    <Typography variant="subtitle2">
+                      Make this the default API Key
+                    </Typography>
+                  }
+                />
+                {errors.isDefault && (
+                  <Typography variant="caption" sx={{ display: "block", color: "error.main", ml: 3.75 }}>
+                    {errors.isDefault}
+                  </Typography>
+                )}
+                <Typography variant="caption" sx={{ display: "block", color: "text.secondary", ml: 3.75 }}>
                   If set, this API key will be used by default for operations that require it.
-                </p>
-              </div>
+                </Typography>
+              </Box>
             )}
             {mode === "create" && userRole && userRole === "admin" && (
-              <div className="pt-2 border-t border-gray-100 mt-4">
-                <label className="flex items-center space-x-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    name="isSystemApiKey"
-                    checked={!!formData.isSystemApiKey}
-                    onChange={handleChange}
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                  />
-                  <span className="text-sm font-medium text-gray-700">
-                    Make this a System API Key
-                  </span>
-                </label>
-                {errors.isSystemApiKey && <p className="text-red-500 text-xs mt-1 ml-7">{errors.isSystemApiKey}</p>}
-                <p className="text-xs text-gray-500 mt-1 ml-7">
+              <Box sx={{ pt: 1, borderTop: "1px solid", borderColor: "divider" }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="isSystemApiKey"
+                      checked={!!formData.isSystemApiKey}
+                      onChange={handleChange}
+                      size="small"
+                    />
+                  }
+                  label={
+                    <Typography variant="subtitle2">
+                      Make this a System API Key
+                    </Typography>
+                  }
+                />
+                {errors.isSystemApiKey && (
+                  <Typography variant="caption" sx={{ display: "block", color: "error.main", ml: 3.75 }}>
+                    {errors.isSystemApiKey}
+                  </Typography>
+                )}
+                <Typography variant="caption" sx={{ display: "block", color: "text.secondary", ml: 3.75 }}>
                   System API keys can be used by all users who have system access enabled.
-                </p>
-              </div>
+                </Typography>
+              </Box>
             )}
-          </div>
-          <div className="px-6 py-4 border-t border-gray-100 flex justify-end space-x-3 bg-gray-50">
-            <button type="button" onClick={onClose} disabled={isSubmitting} className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium disabled:opacity-50">Cancel</button>
-            <button type="submit" disabled={isSubmitting} className="px-4 py-2 bg-[#3ab55b] text-white rounded-lg hover:bg-green-600 transition-colors text-sm font-medium disabled:opacity-50 flex items-center">
-              {isSubmitting ? "Saving..." : (mode === "create" ? "Create Key" : "Save Changes")}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button type="button" onClick={onClose} disabled={isSubmitting} color="inherit">
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting} variant="contained" color="success">
+            {isSubmitting ? "Saving..." : (mode === "create" ? "Create Key" : "Save Changes")}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
   );
 };
+
+export default ApiKeyFormModal;

--- a/src/components/apikeys/ApiKeyMarkDefaultModal.tsx
+++ b/src/components/apikeys/ApiKeyMarkDefaultModal.tsx
@@ -1,60 +1,85 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import type { ApiKey } from "../../models/ApiKeys";
 
-        import React, { useState } from "react";
-        import { XMarkIcon } from "@heroicons/react/24/solid";
-        import type { ApiKey } from "../../models/ApiKeys";
+interface ApiKeyMarkDefaultModalProps {
+  apiKey: ApiKey | null;
+  onClose: () => void;
+  onConfirm: () => Promise<void> | void;
+}
 
-        interface ApiKeyMarkDefaultModalProps {
-          apiKey: ApiKey | null;
-          onClose: () => void;
-          onConfirm: () => Promise<void> | void;
-        }
+export const ApiKeyMarkDefaultModal: React.FC<ApiKeyMarkDefaultModalProps> = ({ apiKey, onClose, onConfirm }) => {
+  const [loading, setLoading] = useState(false);
 
-        export const ApiKeyMarkDefaultModal: React.FC<ApiKeyMarkDefaultModalProps> = ({ apiKey, onClose, onConfirm }) => {
-          const [loading, setLoading] = useState(false);
+  const handleConfirm = async () => {
+    if (!apiKey) return;
+    try {
+      setLoading(true);
+      await onConfirm();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-          const handleConfirm = async () => {
-            if (!apiKey) return;
-            try {
-              setLoading(true);
-              await onConfirm();
-            } catch (err) {
-              console.error(err);
-            } finally {
-              setLoading(false);
-            }
-          };
+  if (!apiKey) return null;
 
-          if (!apiKey) return null;
+  return (
+    <Dialog open={!!apiKey} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+        }}
+      >
+        <Typography variant="h6" component="span">
+          {apiKey.isDefault
+            ? "¿Desea quitar esta clave como predeterminada?"
+            : "¿Desea marcar esta clave como predeterminada?"}
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="Cerrar"
+          size="small"
+          sx={{ color: "text.disabled", "&:hover": { color: "text.secondary" } }}
+        >
+          <CloseIcon sx={{ fontSize: 20 }} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ color: "text.secondary" }}>
+          {apiKey.isDefault
+            ? `¿Está seguro de que desea quitar "${apiKey.description}" como clave predeterminada?`
+            : `¿Desea marcar "${apiKey.description}" como su clave predeterminada? Esto desmarcará la clave que esté marcada actualmente.`}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading} color="inherit">
+          Cancelar
+        </Button>
+        <Button onClick={handleConfirm} disabled={loading} variant="contained" color="warning">
+          {loading
+            ? "Procesando..."
+            : apiKey.isDefault
+              ? "Quitar como predeterminada"
+              : "Marcar como predeterminada"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
 
-          return (
-            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-              <div className="bg-white rounded-xl shadow-xl max-w-md w-full overflow-hidden transform transition-all">
-                <div className="p-6">
-                  <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-bold text-gray-900">
-                      {apiKey.isDefault ? '¿Desea quitar esta clave como predeterminada?' : '¿Desea marcar esta clave como predeterminada?'}
-                    </h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar">
-                      <XMarkIcon className="h-5 w-5" />
-                    </button>
-                  </div>
-
-                  <p className="text-sm text-gray-600 mb-6">
-                    {apiKey.isDefault
-                      ? `¿Está seguro de que desea quitar "${apiKey.description}" como clave predeterminada?`
-                      : `¿Desea marcar "${apiKey.description}" como su clave predeterminada? Esto desmarcará la clave que esté marcada actualmente.`}
-                  </p>
-
-                  <div className="flex justify-end space-x-3 mt-6">
-                    <button onClick={onClose} disabled={loading} className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium">Cancelar</button>
-                    <button onClick={handleConfirm} disabled={loading} className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors text-sm font-medium">
-                      {loading ? 'Procesando...' : (apiKey.isDefault ? 'Quitar como predeterminada' : 'Marcar como predeterminada')}
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        };
-
-        export default ApiKeyMarkDefaultModal;
+export default ApiKeyMarkDefaultModal;

--- a/src/views/ApiKeys.tsx
+++ b/src/views/ApiKeys.tsx
@@ -1,13 +1,26 @@
 import React, { useState } from "react";
-import { Navbar } from "../components/Navbar";
 import { toast } from "react-toastify";
-import { PlusIcon, XMarkIcon } from "@heroicons/react/24/solid";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import VpnKeyOutlinedIcon from "@mui/icons-material/VpnKeyOutlined";
 import { ApiKeyCard } from "../components/apikeys/ApiKeyCard";
 import { ApiKeyFormModal } from "../components/apikeys/ApiKeyFormModal";
 import { ApiKeyMarkDefaultModal } from "../components/apikeys/ApiKeyMarkDefaultModal";
 import type { ApiKey, ApiKeyFormData } from "../models/ApiKeys";
 import { useApiKeys } from "../hooks/useApiKeys";
 import { useAuth } from "../context";
+import AdminLayout from "../components/admin/AdminLayout";
 
 
 export const ApiKeysPage: React.FC = () => {
@@ -117,33 +130,59 @@ export const ApiKeysPage: React.FC = () => {
   const renderContent = () => {
     if (isLoading) {
       return (
-        <div className="flex flex-col items-center justify-center py-20">
-          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600 mb-4"></div>
-          <p className="text-gray-500 font-medium">Loading your API Keys...</p>
-        </div>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            py: 10,
+          }}
+        >
+          <CircularProgress size={40} sx={{ mb: 2 }} />
+          <Typography sx={{ color: "text.secondary", fontWeight: 500 }}>
+            Loading your API Keys...
+          </Typography>
+        </Box>
       );
     }
     if (apiKeys.length === 0) {
       return (
-        <div className="flex flex-col items-center justify-center py-20 bg-white rounded-xl border border-gray-200 border-dashed shadow-sm">
-          <svg className="h-12 w-12 text-gray-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
-          </svg>
-          <p className="text-gray-500 mb-4 text-center max-w-sm">
-            You don't have any custom API Keys configured yet. Add one to get started.
-          </p>
-          <button
-            onClick={openCreateModal}
-            className="px-4 py-2 bg-blue-50 text-blue-700 rounded-lg hover:bg-blue-100 transition-colors text-sm font-medium border border-blue-200"
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            py: 10,
+            bgcolor: "background.paper",
+            borderRadius: 2,
+            border: "1px dashed",
+            borderColor: "divider",
+            boxShadow: 1,
+          }}
+        >
+          <VpnKeyOutlinedIcon sx={{ fontSize: 48, color: "text.disabled", mb: 2 }} />
+          <Typography
+            sx={{ color: "text.secondary", mb: 2, textAlign: "center", maxWidth: 360 }}
           >
+            You don't have any custom API Keys configured yet. Add one to get started.
+          </Typography>
+          <Button variant="outlined" onClick={openCreateModal}>
             Create your first key
-          </button>
-        </div>
+          </Button>
+        </Box>
       );
     }
 
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)" },
+          gap: 3,
+        }}
+      >
         {apiKeys.map((key) => (
           <ApiKeyCard
             key={key.id}
@@ -155,35 +194,29 @@ export const ApiKeysPage: React.FC = () => {
             isSaving={!!savingIds?.[key.id]}
           />
         ))}
-      </div>
+      </Box>
     );
   };
 
+  const headerActions = (
+    <Button
+      variant="contained"
+      startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+      onClick={openCreateModal}
+    >
+      New API key
+    </Button>
+  );
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <Navbar />
-
-      {/* Contenido Principal */}
-      <div className="max-w-6xl mx-auto p-6">
-        {/* Cabecera */}
-        <div className="flex items-center justify-between mb-8 mt-4">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-800">My API Keys</h1>
-            <p className="text-sm text-gray-500 mt-1">
-              Manage your model configurations and programmatic access keys.
-            </p>
-          </div>
-          <button
-            onClick={openCreateModal}
-            className="flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium shadow-sm"
-          >
-            <PlusIcon className="h-4 w-4 mr-2" />
-            Add New Key
-          </button>
-        </div>
-
+    <AdminLayout
+      title="API Keys"
+      subtitle="Manage your model configurations and programmatic access keys."
+      actions={headerActions}
+    >
+      <Box sx={{ maxWidth: 1100, width: "100%", mx: "auto" }}>
         {renderContent()}
-      </div>
+      </Box>
 
       {/* --- MODAL FORMULARIO (Creación / Edición) --- */}
       <ApiKeyFormModal
@@ -200,36 +233,67 @@ export const ApiKeysPage: React.FC = () => {
       />
 
       {/* --- MODAL DE ELIMINACIÓN --- */}
-      {isDeleteModalOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl max-w-md w-full overflow-hidden transform transition-all">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-bold text-gray-900">Delete API Key?</h3>
-                <button onClick={() => {
-                  setIsDeleteModalOpen(false);
-                  setSelectedKey(null);
-                }} className="text-gray-400 hover:text-gray-500"><XMarkIcon className="h-5 w-5" /></button>
-              </div>
-              <p className="text-sm text-gray-600 mb-6">
-                Are you sure you want to delete the key <span className="font-semibold text-gray-800">"{selectedKey?.description}"</span>?
-                This action cannot be undone and any application using this key will stop working immediately.
-              </p>
+      <Dialog
+        open={isDeleteModalOpen}
+        onClose={() => {
+          setIsDeleteModalOpen(false);
+          setSelectedKey(null);
+        }}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontSize: 18,
+            fontWeight: 700,
+          }}
+        >
+          Delete API Key?
+          <IconButton
+            aria-label="close"
+            onClick={() => {
+              setIsDeleteModalOpen(false);
+              setSelectedKey(null);
+            }}
+            sx={{ color: "text.disabled" }}
+          >
+            <CloseIcon sx={{ fontSize: 20 }} />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            Are you sure you want to delete the key{" "}
+            <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+              "{selectedKey?.description}"
+            </Box>
+            ? This action cannot be undone and any application using this key will
+            stop working immediately.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            variant="outlined"
+            color="inherit"
+            onClick={() => setIsDeleteModalOpen(false)}
+            sx={{ borderColor: "divider", color: "text.primary" }}
+          >
+            Cancel
+          </Button>
+          <Button variant="contained" color="error" onClick={confirmDelete}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
 
-              <div className="flex justify-end space-x-3 mt-6">
-                <button onClick={() => setIsDeleteModalOpen(false)} className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium">Cancel</button>
-                <button onClick={confirmDelete} className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm font-medium">Delete</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
       {/* --- MODAL MARCAR/DESMARCAR DEFAULT --- */}
       {isMarkDefaultModalOpen && (<ApiKeyMarkDefaultModal
         apiKey={selectedKey}
         onClose={() => { setIsMarkDefaultModalOpen(false); setSelectedKey(null); }}
         onConfirm={confirmMarkDefault}
       />)}
-    </div>
+    </AdminLayout>
   );
 };


### PR DESCRIPTION
## What

`/administration/api-keys` came in from the BYOK branch in plain Tailwind/heroicons and without the admin chrome, so it looked nothing like the other admin screens and had no sidebar. This brings it in line with the rest of the migrated workbench admin UI.

- `views/ApiKeys.tsx` now renders inside the shared `AdminLayout` (so it gets the same `AdminSidebar` + header as Administration/Experiments). The page title/subtitle live in the AdminLayout header and the "New API key" action is the header action button. Loading, empty state, the responsive card grid and the delete-confirmation modal are MUI.
- `components/apikeys/ApiKeyCard.tsx` → MUI Card/Chip/IconButton/Tooltip (+ the shared `StatusDot`).
- `components/apikeys/ApiKeyFormModal.tsx` → MUI Dialog + TextField/Select/Checkbox.
- `components/apikeys/ApiKeyMarkDefaultModal.tsx` → MUI Dialog.

No behaviour/data-flow changes: hooks (`useApiKeys`/`useAuth`/`useProviders`), handlers, props and the `VITE_AUTH_SERVICE_BACKEND` endpoints are unchanged — only the presentation moved from Tailwind to MUI.

## Verification

`tsc -b` + `vite build` OK. No Tailwind `className` left (the only remaining `className="mono"` is the adminTheme's JetBrains-Mono global utility, not Tailwind).