### PR TITLE
feat: post-supervisor improvements (editor, API-key model, boletín PDF, whole-LEIA chat)

### DIFF
--- a/src/components/apikeys/ApiKeyFormModal.tsx
+++ b/src/components/apikeys/ApiKeyFormModal.tsx
@@ -37,7 +37,8 @@ export const ApiKeyFormModal: React.FC<ApiKeyFormModalProps> = ({ isOpen, mode, 
   const [formData, setFormData] = useState<Partial<ApiKey>>({});
   const [, setInitialFormData] = useState<Partial<ApiKey> | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const { apiKeysProviderSet, isLoading: isLoadingProviders } = useProviders();
+  const { apiKeysProviderSet, apiKeyProvidersMapped, isLoading: isLoadingProviders } = useProviders();
+  const providerModels = (formData.provider && apiKeyProvidersMapped?.[formData.provider]) || [];
 
   useEffect(() => {
     if (isOpen) {
@@ -50,6 +51,7 @@ export const ApiKeyFormModal: React.FC<ApiKeyFormModalProps> = ({ isOpen, mode, 
           description: "",
           keyValue: "",
           provider: "",
+          model: "",
           isActive: true,
           baseUrl: "",
           managementUrl: "",
@@ -77,6 +79,9 @@ export const ApiKeyFormModal: React.FC<ApiKeyFormModalProps> = ({ isOpen, mode, 
       setFormData(prev => ({ ...prev, [name]: checked }));
     } else if (name === 'isActive') {
       setFormData(prev => ({ ...prev, isActive: value === 'Active' }));
+    } else if (name === 'provider') {
+      // Changing provider invalidates the chosen model.
+      setFormData(prev => ({ ...prev, provider: value, model: "" }));
     } else {
       setFormData(prev => ({ ...prev, [name]: value }));
     }
@@ -195,6 +200,41 @@ export const ApiKeyFormModal: React.FC<ApiKeyFormModalProps> = ({ isOpen, mode, 
                 </Select>
               </FormControl>
             </Stack>
+            <FormControl
+              fullWidth
+              disabled={!formData.provider || isLoadingProviders || providerModels.length === 0}
+            >
+              <InputLabel id="api-key-model-label" shrink>Default Model (Optional)</InputLabel>
+              <Select
+                labelId="api-key-model-label"
+                label="Default Model (Optional)"
+                name="model"
+                value={formData.model || ""}
+                onChange={handleChange}
+                displayEmpty
+                renderValue={(selected) =>
+                  selected
+                    ? (selected as string)
+                    : (
+                      <Typography component="span" sx={{ color: "text.disabled" }}>
+                        {!formData.provider
+                          ? "Select a provider first"
+                          : providerModels.length === 0
+                            ? "No models for this provider"
+                            : "-- none --"}
+                      </Typography>
+                    )
+                }
+              >
+                <MenuItem value=""><em>-- none --</em></MenuItem>
+                {providerModels.map((m) => (
+                  <MenuItem key={m} value={m}>{m}</MenuItem>
+                ))}
+              </Select>
+              <Typography variant="caption" sx={{ color: "text.secondary", mt: 0.5, ml: 1.75 }}>
+                Preselected wherever this key is used (you can still change it there).
+              </Typography>
+            </FormControl>
             <TextField
               label="Base URL (Required for local providers)"
               name="baseUrl"

--- a/src/models/ApiKeys.ts
+++ b/src/models/ApiKeys.ts
@@ -2,6 +2,8 @@ export interface ApiKey {
   id: string;
   description: string;
   provider: string;
+  /** Default model to use with this key (chosen once at key creation). */
+  model?: string;
   baseUrl: string;
   keyValue: string;
   managementUrl?: string;
@@ -15,6 +17,7 @@ export interface ApiKey {
 export interface ApiKeyFormData {
   description: string | undefined;
   provider: string | undefined;
+  model?: string | undefined;
   baseUrl: string | undefined;
   keyValue: string | undefined;
   managementUrl?: string | undefined;

--- a/src/views/replication/sections/LeiasSection.tsx
+++ b/src/views/replication/sections/LeiasSection.tsx
@@ -371,11 +371,19 @@ const LeiaEditor: React.FC<LeiaEditorProps> = ({
               value={currentApiKeyId ?? ""}
               onChange={(e) => {
                 const value = e.target.value;
+                const newKeyId = value === "" ? null : value;
                 onLocalLeiaChange(
                   idx,
                   "runnerConfiguration.apiKeyId",
-                  value === "" ? null : value
+                  newKeyId
                 );
+                // Preselect the key's default model when the current one no
+                // longer fits the new key's provider.
+                const key = apiKeys.find((k) => k.id === newKeyId);
+                const validModels = getValidModels(newKeyId, apiKeys, apiKeyProvidersMapped);
+                if (key?.model && validModels.includes(key.model) && !validModels.includes(currentModelName)) {
+                  onLocalLeiaChange(idx, "runnerConfiguration.modelName", key.model);
+                }
               }}
               renderValue={(selected) => {
                 if (!selected) {

--- a/src/widgets/CodeEditorWidget.tsx
+++ b/src/widgets/CodeEditorWidget.tsx
@@ -4,7 +4,7 @@ import { useLukeTool } from "./useLukeTool";
 import { DEFAULT_PROBLEM } from "./codeEditor/problem";
 import { runJsTests } from "./codeEditor/jsRunner";
 import { runPyTests } from "./codeEditor/pyRunner";
-import type { ProblemDef, TestRunSummary } from "./codeEditor/types";
+import type { EditorLanguage, ProblemDef, TestRunSummary } from "./codeEditor/types";
 
 // Minimal subset of monaco's IStandaloneCodeEditor that we actually use.
 // Avoids pulling the heavy monaco-editor type package as a direct dep.
@@ -51,8 +51,6 @@ function applyEdits(current: string, edits: DiffEdit[]): { next: string; errors:
     return { next, errors, applied };
 }
 
-type Lang = "javascript" | "python";
-
 interface CodeEditorWidgetProps {
     /** Optional per-activity problem definition. Overrides DEFAULT_PROBLEM. */
     params?: Partial<ProblemDef>;
@@ -63,51 +61,51 @@ function mergeProblem(p?: Partial<ProblemDef>): ProblemDef {
     return {
         fnName: p.fnName ?? DEFAULT_PROBLEM.fnName,
         description: p.description ?? DEFAULT_PROBLEM.description,
+        language: p.language ?? DEFAULT_PROBLEM.language ?? "javascript",
         starter: {
             javascript: p.starter?.javascript ?? DEFAULT_PROBLEM.starter.javascript,
             python: p.starter?.python ?? DEFAULT_PROBLEM.starter.python,
+            text: p.starter?.text ?? DEFAULT_PROBLEM.starter.text ?? "",
         },
         tests: p.tests ?? DEFAULT_PROBLEM.tests,
     };
 }
 
-// A widget showing a Monaco editor and exposing one tool to LEIA:
+// Monaco language id for an editor language ("text" → plaintext, no execution).
+const monacoLanguage = (lang: EditorLanguage): string => (lang === "text" ? "plaintext" : lang);
+const starterFor = (problem: ProblemDef, lang: EditorLanguage): string =>
+    lang === "text" ? (problem.starter.text ?? "") : problem.starter[lang];
+
+// A widget showing a Monaco editor and exposing three tools to LEIA:
+// codeEditor_read, codeEditor_applyDiff, codeEditor_runTests.
 //
-//   - codeEditor_runTests() → runs the configured test suite against the
-//     user's current code (JS in a Web Worker, Python via PyScript /
-//     Pyodide) and returns { passed, failed, total, results, error? }.
-//
+// The language is fixed by the instructor (problem.language) — the student
+// cannot switch it. "text" mode is a plain editor with no tests/execution.
 // Code execution is intentionally LEIA-only: there is no Run button.
-// The user writes code and asks LEIA to check it.
 export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
     const problem = useMemo(() => mergeProblem(params), [params]);
+    const language: EditorLanguage = problem.language ?? "javascript";
+    // Tests only make sense for an executable language with a suite defined.
+    const hasTests = language !== "text" && problem.tests.length > 0;
+
     const editorRef = useRef<MinimalEditor | null>(null);
-    const [language, setLanguage] = useState<Lang>("javascript");
     const [running, setRunning] = useState(false);
     const [lastRun, setLastRun] = useState<TestRunSummary | null>(null);
-
-    // Re-seed the editor when the user switches language so they get
-    // the right starter without losing their work in the other lang.
-    const draftsRef = useRef<Record<Lang, string>>({
-        javascript: problem.starter.javascript,
-        python: problem.starter.python,
-    });
-
-    const onLanguageChange = (next: Lang) => {
-        const ed = editorRef.current;
-        if (ed) draftsRef.current[language] = ed.getValue();
-        setLanguage(next);
-        if (ed) ed.setValue(draftsRef.current[next]);
-    };
+    const draftRef = useRef<string>(starterFor(problem, language));
 
     async function runTests(): Promise<TestRunSummary> {
-        const code = editorRef.current?.getValue() ?? draftsRef.current[language];
+        const code = editorRef.current?.getValue() ?? draftRef.current;
         const start = performance.now();
         setRunning(true);
         try {
-            const out = language === "javascript"
-                ? await runJsTests(code, problem.fnName, problem.tests)
-                : await runPyTests(code, problem.fnName, problem.tests);
+            if (!hasTests) {
+                const summary: TestRunSummary = { passed: 0, failed: 0, total: 0, results: [], durationMs: 0 };
+                setLastRun(summary);
+                return summary;
+            }
+            const out = language === "python"
+                ? await runPyTests(code, problem.fnName, problem.tests)
+                : await runJsTests(code, problem.fnName, problem.tests);
             const durationMs = Math.round(performance.now() - start);
             const results = out.results ?? [];
             const passed = results.filter((r) => r.ok).length;
@@ -141,7 +139,7 @@ export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
         "Reads the current content of the in-page Monaco code editor. Returns { content, language, fnName }. Call this whenever the user mentions the editor / their code / 'this' / asks about what they wrote. Always read before suggesting edits.",
         { type: "object", properties: {} },
         async () => ({
-            content: editorRef.current?.getValue() ?? draftsRef.current[language],
+            content: editorRef.current?.getValue() ?? draftRef.current,
             language,
             fnName: problem.fnName,
         }),
@@ -180,7 +178,7 @@ export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
             const { next, errors, applied } = applyEdits(before, edits);
             if (applied > 0) {
                 ed.setValue(next);
-                draftsRef.current[language] = next;
+                draftRef.current = next;
             }
             return { applied, errors, content: applied > 0 ? next : before };
         },
@@ -190,15 +188,9 @@ export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
         <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 360 }}>
             <div style={{ padding: "10px 12px", borderBottom: "1px solid rgba(255,255,255,0.12)", background: "rgba(0,0,0,0.2)" }}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: "#e5e7eb" }}>Code editor — {problem.fnName}()</span>
-                    <select
-                        value={language}
-                        onChange={(e) => onLanguageChange(e.target.value as Lang)}
-                        style={{ marginLeft: "auto", background: "rgba(0,0,0,0.3)", color: "#e5e7eb", border: "1px solid rgba(255,255,255,0.15)", borderRadius: 4, padding: "2px 6px", fontSize: 12 }}
-                    >
-                        <option value="javascript">JavaScript</option>
-                        <option value="python">Python</option>
-                    </select>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "#e5e7eb" }}>
+                        Editor{language !== "text" ? ` — ${problem.fnName}()` : ""}
+                    </span>
                 </div>
                 {problem.description && (
                     <div style={{ marginTop: 6, fontSize: 12, color: "#cbd5e1", lineHeight: 1.4 }}>
@@ -210,8 +202,8 @@ export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
             <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
                 <Editor
                     height="100%"
-                    defaultValue={draftsRef.current[language]}
-                    language={language}
+                    defaultValue={draftRef.current}
+                    language={monacoLanguage(language)}
                     theme="vs-dark"
                     onMount={((ed) => {
                         editorRef.current = ed as unknown as MinimalEditor;
@@ -223,7 +215,7 @@ export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
                     }) as OnMount}
                     onChange={(value) => {
                         const v = value ?? "";
-                        draftsRef.current[language] = v;
+                        draftRef.current = v;
                         // Bridge to the /edit view, which seeds its editor
                         // from localStorage["mermaid_code"].
                         try { localStorage.setItem("mermaid_code", v); } catch { /* ignore */ }
@@ -237,43 +229,45 @@ export function CodeEditorWidget({ params }: CodeEditorWidgetProps = {}) {
                 />
             </div>
 
-            <div style={{ borderTop: "1px solid rgba(255,255,255,0.12)", background: "rgba(0,0,0,0.25)", padding: "8px 12px", color: "#e5e7eb", maxHeight: 220, overflowY: "auto" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
-                    <strong>Tests</strong>
-                    {running && <span style={{ color: "#fbbf24" }}>running…</span>}
-                    {!running && lastRun && (
-                        <span style={{ color: lastRun.failed === 0 && !lastRun.error ? "#34d399" : "#f87171" }}>
-                            {lastRun.error
-                                ? "error"
-                                : `${lastRun.passed} / ${lastRun.total} passed (${lastRun.durationMs} ms)`}
-                        </span>
+            {hasTests && (
+                <div style={{ borderTop: "1px solid rgba(255,255,255,0.12)", background: "rgba(0,0,0,0.25)", padding: "8px 12px", color: "#e5e7eb", maxHeight: 220, overflowY: "auto" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
+                        <strong>Tests</strong>
+                        {running && <span style={{ color: "#fbbf24" }}>running…</span>}
+                        {!running && lastRun && (
+                            <span style={{ color: lastRun.failed === 0 && !lastRun.error ? "#34d399" : "#f87171" }}>
+                                {lastRun.error
+                                    ? "error"
+                                    : `${lastRun.passed} / ${lastRun.total} passed (${lastRun.durationMs} ms)`}
+                            </span>
+                        )}
+                        {!running && !lastRun && (
+                            <span style={{ color: "#94a3b8" }}>not run yet — ask LEIA to check your code</span>
+                        )}
+                    </div>
+                    {lastRun?.error && (
+                        <pre style={{ marginTop: 6, fontSize: 12, color: "#fca5a5", whiteSpace: "pre-wrap" }}>{lastRun.error}</pre>
                     )}
-                    {!running && !lastRun && (
-                        <span style={{ color: "#94a3b8" }}>not run yet — ask LEIA to check your code</span>
+                    {lastRun?.results && lastRun.results.length > 0 && (
+                        <ul style={{ marginTop: 6, paddingLeft: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 4 }}>
+                            {lastRun.results.map((r, i) => (
+                                <li key={i} style={{ fontSize: 12, color: r.ok ? "#86efac" : "#fca5a5" }}>
+                                    <span style={{ marginRight: 6 }}>{r.ok ? "✓" : "✗"}</span>
+                                    <span>{r.name}</span>
+                                    {!r.ok && r.error && (
+                                        <div style={{ marginLeft: 18, color: "#fca5a5", opacity: 0.85 }}>{r.error}</div>
+                                    )}
+                                    {!r.ok && !r.error && (
+                                        <div style={{ marginLeft: 18, color: "#94a3b8", opacity: 0.85 }}>
+                                            expected {JSON.stringify(r.expected)}, got {JSON.stringify(r.actual)}
+                                        </div>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
                     )}
                 </div>
-                {lastRun?.error && (
-                    <pre style={{ marginTop: 6, fontSize: 12, color: "#fca5a5", whiteSpace: "pre-wrap" }}>{lastRun.error}</pre>
-                )}
-                {lastRun?.results && lastRun.results.length > 0 && (
-                    <ul style={{ marginTop: 6, paddingLeft: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 4 }}>
-                        {lastRun.results.map((r, i) => (
-                            <li key={i} style={{ fontSize: 12, color: r.ok ? "#86efac" : "#fca5a5" }}>
-                                <span style={{ marginRight: 6 }}>{r.ok ? "✓" : "✗"}</span>
-                                <span>{r.name}</span>
-                                {!r.ok && r.error && (
-                                    <div style={{ marginLeft: 18, color: "#fca5a5", opacity: 0.85 }}>{r.error}</div>
-                                )}
-                                {!r.ok && !r.error && (
-                                    <div style={{ marginLeft: 18, color: "#94a3b8", opacity: 0.85 }}>
-                                        expected {JSON.stringify(r.expected)}, got {JSON.stringify(r.actual)}
-                                    </div>
-                                )}
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
+            )}
         </div>
     );
 }

--- a/src/widgets/catalog.ts
+++ b/src/widgets/catalog.ts
@@ -16,8 +16,8 @@ export interface WidgetCatalogEntry {
 export const WIDGET_CATALOG: WidgetCatalogEntry[] = [
     {
         widgetType: "codeEditor",
-        label: "Code editor",
-        description: "Monaco code editor. LEIA can read, comment and rewrite code while you talk.",
+        label: "Editor",
+        description: "Monaco editor (JavaScript, Python or plain text). LEIA can read, comment and rewrite the content while you talk.",
         Component: CodeEditorWidget,
     },
 ];

--- a/src/widgets/codeEditor/problem.ts
+++ b/src/widgets/codeEditor/problem.ts
@@ -5,6 +5,7 @@ import type { ProblemDef } from "./types";
 // own statement + tests.
 export const DEFAULT_PROBLEM: ProblemDef = {
     fnName: "twoSum",
+    language: "javascript",
     description:
         "Given an array of integers `nums` and an integer `target`, return the indices of the two numbers that add up to `target`. Each input has exactly one solution, and you may not use the same element twice.",
     starter: {

--- a/src/widgets/codeEditor/types.ts
+++ b/src/widgets/codeEditor/types.ts
@@ -23,13 +23,19 @@ export interface TestRunSummary {
     durationMs: number;
 }
 
+/** Editor language. "text" is a plain-text editor with no execution/tests. */
+export type EditorLanguage = "javascript" | "python" | "text";
+
 export interface ProblemDef {
     /** Function name the user must implement. */
     fnName: string;
     description: string;
+    /** Language the instructor fixed for this activity. The student cannot change it. */
+    language?: EditorLanguage;
     starter: {
         javascript: string;
         python: string;
+        text?: string;
     };
     tests: TestCase[];
 }


### PR DESCRIPTION
Editor widget: 'text' language, instructor-fixed language (student can't change), hide 'Tests' when none, rename to 'Editor'. Default model per API key (preselected in the per-LEIA runner config).