### PR TITLE
Feature/gen img

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # OWN CONFIGURATION
 VITE_APP_BACKEND=http://localhost:3001
+VITE_AVATAR_PUBLIC_URL=http://localhost:9000/leia-images
 
 # AUTH CONFIGURATION
 VITE_AUTH_SERVICE_BACKEND=http://localhost:3005

--- a/src/components/LukeAudioWidget.tsx
+++ b/src/components/LukeAudioWidget.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useLuke } from "@leia-org/luke-client";
 import type { FrontendTool, TranscriptionMessage } from "@leia-org/luke-client";
+import { PersonaAvatar } from "./PersonaAvatar";
 
 interface LukeConfig {
   provider: string;
@@ -11,8 +12,10 @@ interface LukeAudioWidgetProps {
   wsUrl: string;
   token: string;
   lukeConfig: LukeConfig;
-  /** Display name for the LEIA — the first letter is used in the avatar. */
+  /** Display name for the LEIA — used in the avatar fallback. */
   leiaName?: string;
+  /** Persona avatar URL or storage key, when available. */
+  avatarSrc?: string;
   forceMute?: boolean;
   /** Initial visibility of the transcription side panel. */
   showTranscription?: boolean;
@@ -221,6 +224,7 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
   token,
   lukeConfig,
   leiaName,
+  avatarSrc,
   forceMute = false,
   showTranscription: initialShowTranscription = false,
   tools,
@@ -355,8 +359,6 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
     emittedCountRef.current = transcription.length;
   }, [transcription, onTranscriptComplete]);
 
-  const letter = (leiaName?.trim()?.charAt(0) || "L").toUpperCase();
-
   // Halo around the avatar pulses with the ASSISTANT's audio level so you
   // can tell when the LEIA is speaking. The user's own level drives the
   // bottom waveform visualizer instead.
@@ -423,16 +425,14 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
             }}
           />
 
-          {/* Avatar circle */}
-          <div
-            className="relative w-44 h-44 rounded-full flex items-center justify-center text-white text-7xl font-semibold shadow-2xl"
-            style={{
-              background:
-                "linear-gradient(135deg, #3b82f6 0%, #1e3a8a 100%)",
-            }}
-          >
-            {letter}
-          </div>
+          <PersonaAvatar
+            src={avatarSrc}
+            alt={`${leiaName || "LEIA"} avatar`}
+            label={leiaName || "LEIA"}
+            size="xl"
+            className="relative text-white shadow-2xl"
+            fallbackClassName="bg-gradient-to-br from-blue-500 to-blue-900"
+          />
         </div>
 
         {leiaName && (

--- a/src/components/LukeAudioWidget.tsx
+++ b/src/components/LukeAudioWidget.tsx
@@ -16,6 +16,8 @@ interface LukeAudioWidgetProps {
   leiaName?: string;
   /** Persona avatar URL or storage key, when available. */
   avatarSrc?: string;
+  /** Fallback avatar path to try before initials placeholder. */
+  avatarFallbackSrc?: string;
   forceMute?: boolean;
   /** Initial visibility of the transcription side panel. */
   showTranscription?: boolean;
@@ -225,6 +227,7 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
   lukeConfig,
   leiaName,
   avatarSrc,
+  avatarFallbackSrc,
   forceMute = false,
   showTranscription: initialShowTranscription = false,
   tools,
@@ -427,6 +430,7 @@ export const LukeAudioWidget: React.FC<LukeAudioWidgetProps> = ({
 
           <PersonaAvatar
             src={avatarSrc}
+            fallbackSrc={avatarFallbackSrc}
             alt={`${leiaName || "LEIA"} avatar`}
             label={leiaName || "LEIA"}
             size="xl"

--- a/src/components/PersonaAvatar.tsx
+++ b/src/components/PersonaAvatar.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { buildAvatarCandidateSources } from "../lib/avatar";
 
 interface PersonaAvatarProps {
   src?: string | null;
+  fallbackSrc?: string | null;
   alt: string;
   label?: string | null;
   size?: "sm" | "md" | "lg" | "xl";
@@ -21,29 +23,6 @@ const textSizeClasses = {
   md: "text-sm",
   lg: "text-lg",
   xl: "text-7xl",
-};
-
-const avatarPublicBaseUrl = (import.meta.env.VITE_AVATAR_PUBLIC_URL || "")
-  .replace(/\/+$/g, "");
-
-export const resolveAvatarSrc = (value?: string | null): string => {
-  const trimmedValue = typeof value === "string" ? value.trim() : "";
-  if (!trimmedValue) return "";
-
-  if (/^(https?:|data:image\/|blob:)/i.test(trimmedValue)) {
-    return trimmedValue;
-  }
-
-  const normalizedValue = trimmedValue.replace(/^\/+/g, "");
-  if (!normalizedValue.startsWith("images/")) {
-    return "";
-  }
-
-  if (!avatarPublicBaseUrl) {
-    return normalizedValue;
-  }
-
-  return `${avatarPublicBaseUrl}/${normalizedValue}`;
 };
 
 export const getInitials = (value?: string | null): string => {
@@ -66,19 +45,24 @@ export const getInitials = (value?: string | null): string => {
 
 export const PersonaAvatar: React.FC<PersonaAvatarProps> = ({
   src,
+  fallbackSrc,
   alt,
   label,
   size = "md",
   className = "",
   fallbackClassName = "bg-blue-50 text-blue-700",
 }) => {
-  const resolvedSrc = resolveAvatarSrc(src);
-  const [imageFailed, setImageFailed] = React.useState(false);
+  const candidateSources = React.useMemo(
+    () => buildAvatarCandidateSources(src, fallbackSrc),
+    [src, fallbackSrc],
+  );
+  const [currentSourceIndex, setCurrentSourceIndex] = React.useState(0);
+  const resolvedSrc = candidateSources[currentSourceIndex] || "";
   const initials = getInitials(label || alt);
 
   React.useEffect(() => {
-    setImageFailed(false);
-  }, [resolvedSrc]);
+    setCurrentSourceIndex(0);
+  }, [candidateSources]);
 
   return (
     <div
@@ -86,13 +70,20 @@ export const PersonaAvatar: React.FC<PersonaAvatarProps> = ({
       title={label || alt}
       aria-label={alt}
     >
-      {resolvedSrc && !imageFailed ? (
+      {resolvedSrc ? (
         <img
           src={resolvedSrc}
           alt={alt}
           className="h-full w-full object-cover"
           loading="lazy"
-          onError={() => setImageFailed(true)}
+          onError={() => {
+            setCurrentSourceIndex((previousIndex) => {
+              const nextIndex = previousIndex + 1;
+              return nextIndex < candidateSources.length
+                ? nextIndex
+                : candidateSources.length;
+            });
+          }}
         />
       ) : (
         <span

--- a/src/components/PersonaAvatar.tsx
+++ b/src/components/PersonaAvatar.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+
+interface PersonaAvatarProps {
+  src?: string | null;
+  alt: string;
+  label?: string | null;
+  size?: "sm" | "md" | "lg" | "xl";
+  className?: string;
+  fallbackClassName?: string;
+}
+
+const sizeClasses = {
+  sm: "w-8 h-8",
+  md: "w-12 h-12",
+  lg: "w-16 h-16",
+  xl: "w-44 h-44",
+};
+
+const textSizeClasses = {
+  sm: "text-xs",
+  md: "text-sm",
+  lg: "text-lg",
+  xl: "text-7xl",
+};
+
+const avatarPublicBaseUrl = (import.meta.env.VITE_AVATAR_PUBLIC_URL || "")
+  .replace(/\/+$/g, "");
+
+export const resolveAvatarSrc = (value?: string | null): string => {
+  const trimmedValue = typeof value === "string" ? value.trim() : "";
+  if (!trimmedValue) return "";
+
+  if (/^(https?:|data:image\/|blob:)/i.test(trimmedValue)) {
+    return trimmedValue;
+  }
+
+  const normalizedValue = trimmedValue.replace(/^\/+/g, "");
+  if (!normalizedValue.startsWith("images/")) {
+    return "";
+  }
+
+  if (!avatarPublicBaseUrl) {
+    return normalizedValue;
+  }
+
+  return `${avatarPublicBaseUrl}/${normalizedValue}`;
+};
+
+export const getInitials = (value?: string | null): string => {
+  const cleanValue = (value || "")
+    .replace(/\bavatar\b/gi, "")
+    .trim();
+
+  if (!cleanValue) return "L";
+
+  const parts = cleanValue
+    .split(/[\s._-]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length === 0) return "L";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+};
+
+export const PersonaAvatar: React.FC<PersonaAvatarProps> = ({
+  src,
+  alt,
+  label,
+  size = "md",
+  className = "",
+  fallbackClassName = "bg-blue-50 text-blue-700",
+}) => {
+  const resolvedSrc = resolveAvatarSrc(src);
+  const [imageFailed, setImageFailed] = React.useState(false);
+  const initials = getInitials(label || alt);
+
+  React.useEffect(() => {
+    setImageFailed(false);
+  }, [resolvedSrc]);
+
+  return (
+    <div
+      className={`${sizeClasses[size]} ${className} ${fallbackClassName} rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden`}
+      title={label || alt}
+      aria-label={alt}
+    >
+      {resolvedSrc && !imageFailed ? (
+        <img
+          src={resolvedSrc}
+          alt={alt}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        <span
+          className={`${textSizeClasses[size]} font-semibold leading-none`}
+          aria-hidden="true"
+        >
+          {initials}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_APP_BACKEND: string
+  readonly VITE_AVATAR_PUBLIC_URL?: string
 }
 
 interface ImportMeta {

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,57 @@
+export type AvatarEntityPathSegment = "leias" | "personas" | "problems";
+
+const avatarPublicBaseUrl = (import.meta.env.VITE_AVATAR_PUBLIC_URL || "").replace(
+  /\/+$/g,
+  "",
+);
+
+export const buildOriginalAvatarPath = (
+  entity: AvatarEntityPathSegment,
+  id?: string | null,
+): string => {
+  const trimmedId = id?.trim();
+  if (!trimmedId) {
+    return "";
+  }
+
+  return `/images/${entity}/${trimmedId}/avatar/original.webp`;
+};
+
+export const resolveAvatarSrc = (value?: string | null): string => {
+  const trimmedValue = typeof value === "string" ? value.trim() : "";
+  if (!trimmedValue) return "";
+
+  if (/^(https?:|data:image\/|blob:)/i.test(trimmedValue)) {
+    return trimmedValue;
+  }
+
+  const normalizedValue = trimmedValue.replace(/^\/+/g, "");
+  if (!normalizedValue.startsWith("images/")) {
+    return "";
+  }
+
+  if (!avatarPublicBaseUrl) {
+    return `/${normalizedValue}`;
+  }
+
+  return `${avatarPublicBaseUrl}/${normalizedValue}`;
+};
+
+export const buildAvatarCandidateSources = (
+  primarySrc?: string | null,
+  fallbackSrc?: string | null,
+): string[] => {
+  const candidates: string[] = [];
+
+  const resolvedPrimary = resolveAvatarSrc(primarySrc);
+  if (resolvedPrimary) {
+    candidates.push(resolvedPrimary);
+  }
+
+  const resolvedFallback = resolveAvatarSrc(fallbackSrc);
+  if (resolvedFallback && !candidates.includes(resolvedFallback)) {
+    candidates.push(resolvedFallback);
+  }
+
+  return candidates;
+};

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -1067,7 +1067,7 @@ export const Chat = () => {
                 }`}
               >
                 <div
-                  className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${
+                  className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${
                     msg.isLeia ? "bg-blue-50" : "bg-blue-600"
                   }`}
                 >
@@ -1078,17 +1078,17 @@ export const Chat = () => {
                         fallbackSrc={personaAvatarFallbackSrc}
                         alt={`${leiaName || "LEIA"} avatar`}
                         label={leiaName || "LEIA"}
-                        size="sm"
+                        size="md"
                       />
                     ) : (
-                      <UserCircleIcon className="w-5 h-5 text-blue-700" />
+                      <UserCircleIcon className="w-6 h-6 text-blue-700" />
                     )
                   ) : (
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 20 20"
                       fill="currentColor"
-                      className="w-5 h-5 text-white"
+                      className="w-6 h-6 text-white"
                     >
                       <path d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z" />
                     </svg>
@@ -1149,16 +1149,18 @@ export const Chat = () => {
             {sendingMessage && (
               <div className="flex items-end gap-2">
                 {personaAvatar || personaAvatarFallbackSrc ? (
-                  <PersonaAvatar
-                    src={personaAvatar}
-                    fallbackSrc={personaAvatarFallbackSrc}
-                    alt={`${leiaName || "LEIA"} avatar`}
-                    label={leiaName || "LEIA"}
-                    size="sm"
-                  />
+                  <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden bg-blue-50">
+                    <PersonaAvatar
+                      src={personaAvatar}
+                      fallbackSrc={personaAvatarFallbackSrc}
+                      alt={`${leiaName || "LEIA"} avatar`}
+                      label={leiaName || "LEIA"}
+                      size="md"
+                    />
+                  </div>
                 ) : (
-                  <div className="w-8 h-8 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0">
-                    <UserCircleIcon className="w-5 h-5 text-blue-700" />
+                  <div className="w-10 h-10 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0">
+                    <UserCircleIcon className="w-6 h-6 text-blue-700" />
                   </div>
                 )}
                 <div className="min-w-[60px] bg-white border border-gray-200 rounded-t-2xl rounded-r-2xl rounded-bl-md px-4 py-3 shadow-sm">

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -10,6 +10,7 @@ import { LiveTranscriptionNotice } from "../components/LiveTranscriptionNotice";
 import { LukeAudioWidget } from "../components/LukeAudioWidget";
 import { PersonaAvatar } from "../components/PersonaAvatar";
 import { SessionTimer } from "../components/SessionTimer";
+import { buildOriginalAvatarPath } from "../lib/avatar";
 import {
   VoiceModeWithWidgets,
   findCatalogEntry,
@@ -68,6 +69,34 @@ const extractPersonaSpec = (value: unknown): Record<string, unknown> => {
     | undefined;
 
   return leia?.leia?.spec?.persona?.spec || {};
+};
+
+const extractLeiaResourceIds = (
+  value: unknown,
+): { leiaId: string; personaId: string; problemId: string } => {
+  const leiaEntry = value as
+    | {
+        id?: unknown;
+        leia?: {
+          id?: unknown;
+          spec?: {
+            persona?: {
+              id?: unknown;
+            };
+            problem?: {
+              id?: unknown;
+            };
+          };
+        };
+      }
+    | null
+    | undefined;
+
+  return {
+    leiaId: getString(leiaEntry?.leia?.id ?? leiaEntry?.id),
+    personaId: getString(leiaEntry?.leia?.spec?.persona?.id),
+    problemId: getString(leiaEntry?.leia?.spec?.problem?.id),
+  };
 };
 
 interface Message {
@@ -146,6 +175,9 @@ export const Chat = () => {
   } | null>(null);
   const [leiaName, setLeiaName] = useState<string | null>(null);
   const [personaAvatar, setPersonaAvatar] = useState<string | null>(null);
+  const [personaAvatarFallbackSrc, setPersonaAvatarFallbackSrc] = useState<
+    string | null
+  >(null);
   const [hideAudioTranscription, setHideAudioTranscription] = useState(false);
   const chatMessagesRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -350,6 +382,12 @@ export const Chat = () => {
             null,
         );
         setPersonaAvatar(getString(personaSpec.avatar) || null);
+        const resourceIds = extractLeiaResourceIds(response.data.leia);
+        setPersonaAvatarFallbackSrc(
+          buildOriginalAvatarPath("personas", resourceIds.personaId) ||
+            buildOriginalAvatarPath("leias", resourceIds.leiaId) ||
+            null,
+        );
         setReplication(response.data.replication);
         setSession(response.data.session);
         setTooltipMessage(
@@ -896,6 +934,7 @@ export const Chat = () => {
                   lukeConfig={lukeConfig}
                   leiaName={leiaName || undefined}
                   avatarSrc={personaAvatar || undefined}
+                  avatarFallbackSrc={personaAvatarFallbackSrc || undefined}
                   forceMute={showInstructions}
                   showTranscription={!hideAudioTranscription}
                   mode="inline"
@@ -913,6 +952,7 @@ export const Chat = () => {
                       lukeConfig={lukeConfig}
                       leiaName={leiaName || undefined}
                       avatarSrc={personaAvatar || undefined}
+                      avatarFallbackSrc={personaAvatarFallbackSrc || undefined}
                       forceMute={showInstructions}
                       showTranscription={!hideAudioTranscription}
                       mode="inline"
@@ -1032,9 +1072,10 @@ export const Chat = () => {
                   }`}
                 >
                   {msg.isLeia ? (
-                    personaAvatar ? (
+                    personaAvatar || personaAvatarFallbackSrc ? (
                       <PersonaAvatar
                         src={personaAvatar}
+                        fallbackSrc={personaAvatarFallbackSrc}
                         alt={`${leiaName || "LEIA"} avatar`}
                         label={leiaName || "LEIA"}
                         size="sm"
@@ -1107,9 +1148,10 @@ export const Chat = () => {
             ))}
             {sendingMessage && (
               <div className="flex items-end gap-2">
-                {personaAvatar ? (
+                {personaAvatar || personaAvatarFallbackSrc ? (
                   <PersonaAvatar
                     src={personaAvatar}
+                    fallbackSrc={personaAvatarFallbackSrc}
                     alt={`${leiaName || "LEIA"} avatar`}
                     label={leiaName || "LEIA"}
                     size="sm"

--- a/src/views/Chat.tsx
+++ b/src/views/Chat.tsx
@@ -8,6 +8,7 @@ import { useLukeToken } from "../hooks/useLukeAudio";
 import { AudioControls } from "../components/AudioControls";
 import { LiveTranscriptionNotice } from "../components/LiveTranscriptionNotice";
 import { LukeAudioWidget } from "../components/LukeAudioWidget";
+import { PersonaAvatar } from "../components/PersonaAvatar";
 import { SessionTimer } from "../components/SessionTimer";
 import {
   VoiceModeWithWidgets,
@@ -47,6 +48,27 @@ const TypingAnimation = () => (
     ></div>
   </div>
 );
+
+const getString = (value: unknown): string => {
+  return typeof value === "string" ? value.trim() : "";
+};
+
+const extractPersonaSpec = (value: unknown): Record<string, unknown> => {
+  const leia = value as
+    | {
+        leia?: {
+          spec?: {
+            persona?: {
+              spec?: Record<string, unknown>;
+            };
+          };
+        };
+      }
+    | null
+    | undefined;
+
+  return leia?.leia?.spec?.persona?.spec || {};
+};
 
 interface Message {
   text: string;
@@ -123,6 +145,7 @@ export const Chat = () => {
     }>;
   } | null>(null);
   const [leiaName, setLeiaName] = useState<string | null>(null);
+  const [personaAvatar, setPersonaAvatar] = useState<string | null>(null);
   const [hideAudioTranscription, setHideAudioTranscription] = useState(false);
   const chatMessagesRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -314,13 +337,19 @@ export const Chat = () => {
       );
 
       if (response.status === 200) {
+        const personaSpec = extractPersonaSpec(response.data.leia);
         setExercise(response.data.leia.leia.spec.problem.spec);
         setConfiguration(response.data.leia.configuration);
         const durationSeconds = response.data.replication?.duration;
         if (typeof durationSeconds === "number" && durationSeconds > 0) {
           setSessionTime(durationSeconds / 60);
         }
-        setLeiaName(response.data.leia.leia.spec.persona?.spec?.firstName || null);
+        setLeiaName(
+          getString(personaSpec.firstName) ||
+            getString(personaSpec.fullName) ||
+            null,
+        );
+        setPersonaAvatar(getString(personaSpec.avatar) || null);
         setReplication(response.data.replication);
         setSession(response.data.session);
         setTooltipMessage(
@@ -866,6 +895,7 @@ export const Chat = () => {
                   token={lukeToken.token!}
                   lukeConfig={lukeConfig}
                   leiaName={leiaName || undefined}
+                  avatarSrc={personaAvatar || undefined}
                   forceMute={showInstructions}
                   showTranscription={!hideAudioTranscription}
                   mode="inline"
@@ -882,6 +912,7 @@ export const Chat = () => {
                       token={lukeToken.token!}
                       lukeConfig={lukeConfig}
                       leiaName={leiaName || undefined}
+                      avatarSrc={personaAvatar || undefined}
                       forceMute={showInstructions}
                       showTranscription={!hideAudioTranscription}
                       mode="inline"
@@ -996,12 +1027,21 @@ export const Chat = () => {
                 }`}
               >
                 <div
-                  className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${
                     msg.isLeia ? "bg-blue-50" : "bg-blue-600"
                   }`}
                 >
                   {msg.isLeia ? (
-                    <UserCircleIcon className="w-5 h-5 text-blue-700" />
+                    personaAvatar ? (
+                      <PersonaAvatar
+                        src={personaAvatar}
+                        alt={`${leiaName || "LEIA"} avatar`}
+                        label={leiaName || "LEIA"}
+                        size="sm"
+                      />
+                    ) : (
+                      <UserCircleIcon className="w-5 h-5 text-blue-700" />
+                    )
                   ) : (
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -1067,9 +1107,18 @@ export const Chat = () => {
             ))}
             {sendingMessage && (
               <div className="flex items-end gap-2">
-                <div className="w-8 h-8 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0">
-                  <UserCircleIcon className="w-5 h-5 text-blue-700" />
-                </div>
+                {personaAvatar ? (
+                  <PersonaAvatar
+                    src={personaAvatar}
+                    alt={`${leiaName || "LEIA"} avatar`}
+                    label={leiaName || "LEIA"}
+                    size="sm"
+                  />
+                ) : (
+                  <div className="w-8 h-8 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0">
+                    <UserCircleIcon className="w-5 h-5 text-blue-700" />
+                  </div>
+                )}
                 <div className="min-w-[60px] bg-white border border-gray-200 rounded-t-2xl rounded-r-2xl rounded-bl-md px-4 py-3 shadow-sm">
                   <TypingAnimation />
                 </div>


### PR DESCRIPTION
- Adds avatar display support in the workbench chat.
- Replaces initials-only Luke avatar UI with a reusable PersonaAvatar component.
- Resolves avatars from full URLs, data URLs, blob URLs, or S3-style images/... keys.
- Adds fallback avatar paths for persona/LEIA resources.
- Adds VITE_AVATAR_PUBLIC_URL for public avatar URL resolution.
- Improves avatar sizing in messages and typing states.