### PR TITLE
feat: use centralized Auth session

### DIFF
--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -17,16 +17,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
 
-  const isTokenExpired = (token: string): boolean => {
-    try {
-      const decoded = jwtDecode<DecodedToken>(token);
-      const currentTime = Date.now() / 1000;
-      return decoded.exp < currentTime;
-    } catch {
-      return true;
-    }
-  };
-
   const decodeToken = (token: string): DecodedToken | null => {
     try {
       return jwtDecode<DecodedToken>(token);
@@ -36,19 +26,50 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  const login = (newToken: string) => {
-    localStorage.setItem("token", newToken);
+  const login = useCallback((newToken: string) => {
     setToken(newToken);
     const decoded = decodeToken(newToken);
     setUser(decoded);
-  };
+  }, []);
 
-  const logout = useCallback(() => {
-    localStorage.removeItem("token");
+  const clearLocalSession = useCallback(() => {
     setToken(null);
     setUser(null);
+  }, []);
+
+  const syncSession = useCallback(async () => {
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_AUTH_SERVICE_BACKEND}/api/v1/users/session`,
+        { credentials: "include" },
+      );
+      if (!response.ok) {
+        clearLocalSession();
+        return false;
+      }
+
+      const data = await response.json() as { token?: string };
+      if (!data.token) {
+        clearLocalSession();
+        return false;
+      }
+
+      login(data.token);
+      return true;
+    } catch (error) {
+      console.error("Error synchronizing Auth session:", error);
+      return false;
+    }
+  }, [clearLocalSession, login]);
+
+  const logout = useCallback(() => {
+    void fetch(
+      `${import.meta.env.VITE_AUTH_SERVICE_BACKEND}/api/v1/users/logout`,
+      { method: "POST", credentials: "include" },
+    ).catch((error) => console.error("Error closing Auth session:", error));
+    clearLocalSession();
     navigate("/login");
-  }, [navigate]);
+  }, [clearLocalSession, navigate]);
 
   useEffect(() => {
     const responseInterceptor = axios.interceptors.response.use(
@@ -80,35 +101,19 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, [logout]);
 
   useEffect(() => {
-    const storedToken = localStorage.getItem("token");
-
-    if (storedToken) {
-      if (isTokenExpired(storedToken)) {
-        localStorage.removeItem("token");
-        setToken(null);
-        setUser(null);
-      } else {
-        const decoded = decodeToken(storedToken);
-        setToken(storedToken);
-        setUser(decoded);
-      }
-    }
-
-    setIsLoading(false);
-  }, []);
+    localStorage.removeItem("token");
+    void syncSession().finally(() => setIsLoading(false));
+  }, [syncSession]);
 
   useEffect(() => {
-    if (!token) return;
-
-    const interval = setInterval(() => {
-      if (isTokenExpired(token)) {
-        toast.info("Tu sesión ha expirado por inactividad.");
-        logout();
-      }
-    }, 60000);
-
-    return () => clearInterval(interval);
-  }, [token, logout]);
+    const refresh = () => void syncSession();
+    const interval = window.setInterval(refresh, 5 * 60 * 1000);
+    window.addEventListener("focus", refresh);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [syncSession]);
 
   const value: AuthContextType = {
     token,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -17,7 +17,7 @@ export async function authFetch(url: string, token: string|null, options: Reques
   };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(url, { ...options, headers });
+  const res = await fetch(url, { ...options, headers, credentials: 'include' });
   if (res.status === 401 && !url.includes('/login')) {
     window.dispatchEvent(new CustomEvent('auth-unauthorized'));
   }

--- a/src/views/AdminLogin.tsx
+++ b/src/views/AdminLogin.tsx
@@ -88,7 +88,8 @@ export const AdminLogin: React.FC = () => {
           ...(isTurnstileEnabled && {
             "cf-turnstile-response": turnstileToken,
           }),
-        }
+        },
+        { withCredentials: true },
       );
       const newToken = response.data.token;
 


### PR DESCRIPTION
## Summary
- exchange the Auth HttpOnly session cookie for a short-lived access token at startup
- keep access tokens in memory instead of localStorage
- refresh the Auth session on focus and every five minutes
- send credentials for login, authenticated fetches, and logout

## Rollout
Deploy after the leia-auth session endpoints and the Workbench backend JWT validation changes.

## Validation
- focused ESLint passes
- production build passes